### PR TITLE
Revise API service: tasks.service.ts

### DIFF
--- a/server/services/__tests__/tasks.service.test.ts
+++ b/server/services/__tests__/tasks.service.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockPrisma,
+  mockIsPrismaConflictError,
+  mockIsPrismaForeignKeyError,
+  mockIsPrismaNotFoundError,
+} = vi.hoisted(() => {
+  return {
+    mockPrisma: {
+      task: {
+        findMany: vi.fn(),
+        create: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      },
+      user: {
+        findUnique: vi.fn(),
+      },
+      priority: {
+        findUnique: vi.fn(),
+      },
+      status: {
+        findUnique: vi.fn(),
+      },
+      project: {
+        findUnique: vi.fn(),
+      },
+      label: {
+        findMany: vi.fn(),
+      },
+      taskLabel: {
+        findMany: vi.fn(),
+      },
+    },
+    mockIsPrismaConflictError: vi.fn(() => false),
+    mockIsPrismaForeignKeyError: vi.fn(() => false),
+    mockIsPrismaNotFoundError: vi.fn(() => false),
+  };
+});
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+  isPrismaConflictError: mockIsPrismaConflictError,
+  isPrismaForeignKeyError: mockIsPrismaForeignKeyError,
+  isPrismaNotFoundError: mockIsPrismaNotFoundError,
+  normalizeTaskWithDetails: <T>(entity: T) => entity,
+  normalizeManyTasksWithDetails: <T>(entities: T[]) => entities,
+}));
+
+import { TasksService } from "../tasks.service";
+
+describe("TasksService", () => {
+  let service: TasksService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TasksService();
+  });
+
+  it("returns 404 when no tasks are found", async () => {
+    mockPrisma.task.findMany.mockResolvedValueOnce([]);
+
+    const result = await service.get();
+
+    expect(result.httpStatus).toBe(404);
+    expect(result.message).toBe("No tasks found");
+  });
+
+  it("returns 400 when create payload is missing title", async () => {
+    const result = await service.create({ creatorId: "u1" });
+
+    expect(result.httpStatus).toBe(400);
+    expect(result.message).toBe("title is required");
+    expect(mockPrisma.task.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when create payload is missing creatorId", async () => {
+    const result = await service.create({ title: "Task A" });
+
+    expect(result.httpStatus).toBe(400);
+    expect(result.message).toBe("creatorId is required");
+    expect(mockPrisma.task.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when creator is not found during create", async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(null);
+
+    const result = await service.create({
+      title: "Task A",
+      creatorId: "missing-user",
+    });
+
+    expect(result.httpStatus).toBe(404);
+    expect(result.message).toBe("User with ID missing-user not found");
+    expect(mockPrisma.task.create).not.toHaveBeenCalled();
+  });
+
+  it("creates a task when payload is valid", async () => {
+    const created = {
+      id: "t1",
+      title: "Task A",
+      creatorId: "u1",
+    };
+
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.task.create.mockResolvedValueOnce(created);
+
+    const result = await service.create({
+      title: "Task A",
+      creatorId: "u1",
+    });
+
+    expect(result.httpStatus).toBe(201);
+    expect(result.message).toBe("Create a task");
+    expect(result.data).toEqual(created);
+    expect(mockPrisma.task.create).toHaveBeenCalledWith({
+      data: {
+        title: "Task A",
+        creatorId: "u1",
+      },
+      include: expect.any(Object),
+    });
+  });
+
+  it("returns 400 when update payload has no fields", async () => {
+    const result = await service.update("t1", {});
+
+    expect(result.httpStatus).toBe(400);
+    expect(result.message).toBe(
+      "At least one field is required to update a task",
+    );
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when update target does not exist", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce(null);
+
+    const result = await service.update("missing-task", { title: "Updated" });
+
+    expect(result.httpStatus).toBe(404);
+    expect(result.message).toBe("Task with ID missing-task not found");
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when update title is empty", async () => {
+    const result = await service.update("t1", { title: "  " });
+
+    expect(result.httpStatus).toBe(400);
+    expect(result.message).toBe("title cannot be empty");
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when delete target does not exist", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce(null);
+
+    const result = await service.delete("missing-task");
+
+    expect(result.httpStatus).toBe(404);
+    expect(result.message).toBe("Task with ID missing-task not found");
+    expect(mockPrisma.task.delete).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when addLabels receives an empty array", async () => {
+    const result = await service.addLabels("t1", []);
+
+    expect(result.httpStatus).toBe(400);
+    expect(result.message).toBe("labelIds must be a non-empty array");
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when addLabels references unknown labels", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.label.findMany.mockResolvedValueOnce([{ id: "l1" }]);
+
+    const result = await service.addLabels("t1", ["l1", "l2"]);
+
+    expect(result.httpStatus).toBe(404);
+    expect(result.message).toBe("Labels not found: l2");
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
+  it("adds labels with deduplicated ids", async () => {
+    const updated = { id: "t1", labelLinks: [] };
+
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.label.findMany.mockResolvedValueOnce([
+      { id: "l1" },
+      { id: "l2" },
+    ]);
+    mockPrisma.taskLabel.findMany.mockResolvedValueOnce([]);
+    mockPrisma.task.update.mockResolvedValueOnce(updated);
+
+    const result = await service.addLabels("t1", ["l1", "l1", "l2"]);
+
+    expect(result.httpStatus).toBe(200);
+    expect(result.message).toBe("Add labels to task t1");
+    expect(mockPrisma.task.update).toHaveBeenCalledWith({
+      where: { id: "t1" },
+      data: {
+        labelLinks: {
+          create: [
+            { label: { connect: { id: "l1" } } },
+            { label: { connect: { id: "l2" } } },
+          ],
+        },
+      },
+      include: expect.any(Object),
+    });
+  });
+
+  it("returns 400 when setPriority is called without priorityId", async () => {
+    const result = await service.setPriority(
+      "t1",
+      undefined as unknown as string | null,
+    );
+
+    expect(result.httpStatus).toBe(400);
+    expect(result.message).toBe("priorityId is required");
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when setPriority references unknown priority", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.priority.findUnique.mockResolvedValueOnce(null);
+
+    const result = await service.setPriority("t1", "p-missing");
+
+    expect(result.httpStatus).toBe(404);
+    expect(result.message).toBe("Priority with ID p-missing not found");
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when assignProject is called without projectId", async () => {
+    const result = await service.assignProject("t1", "   ");
+
+    expect(result.httpStatus).toBe(400);
+    expect(result.message).toBe("projectId is required");
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when assignUser is called without userId", async () => {
+    const result = await service.assignUser("t1", " ");
+
+    expect(result.httpStatus).toBe(400);
+    expect(result.message).toBe("userId is required");
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when watchTask tries to add an existing watcher", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.task.update.mockRejectedValueOnce(new Error("duplicate"));
+    mockIsPrismaConflictError.mockReturnValueOnce(true);
+
+    const result = await service.watchTask("t1", "u1");
+
+    expect(result.httpStatus).toBe(409);
+    expect(result.message).toBe("User u1 is already watching task t1");
+  });
+});

--- a/server/services/tasks.service.ts
+++ b/server/services/tasks.service.ts
@@ -1,10 +1,28 @@
-import { TaskCreateInput, TaskUpdateInput } from "../prisma/generated/models";
 import {
+  isPrismaConflictError,
+  isPrismaForeignKeyError,
+  isPrismaNotFoundError,
   normalizeManyTasksWithDetails,
   normalizeTaskWithDetails,
   prisma,
   standardiseResponse,
 } from "../utils";
+
+type CreateTaskInput = {
+  title?: string;
+  description?: string | null;
+  parentId?: string | null;
+  creatorId?: string;
+  priorityId?: string | null;
+  statusId?: string | null;
+  projectId?: string | null;
+  startDate?: Date | string | null;
+  dueDate?: Date | string | null;
+  estimatedHours?: number | null;
+  isArchived?: boolean;
+};
+
+type UpdateTaskInput = Partial<CreateTaskInput>;
 
 const taskInclude = {
   labelLinks: {
@@ -53,10 +71,223 @@ export class TasksService {
     }
   }
 
-  async create(data: TaskCreateInput) {
+  async create(data: CreateTaskInput) {
+    const title = data.title?.trim();
+    const creatorId = data.creatorId?.trim();
+    const description =
+      data.description === null
+        ? null
+        : data.description !== undefined
+          ? data.description.trim()
+          : undefined;
+    const parentId =
+      data.parentId === null
+        ? null
+        : data.parentId !== undefined
+          ? data.parentId.trim()
+          : undefined;
+    const priorityId =
+      data.priorityId === null
+        ? null
+        : data.priorityId !== undefined
+          ? data.priorityId.trim()
+          : undefined;
+    const statusId =
+      data.statusId === null
+        ? null
+        : data.statusId !== undefined
+          ? data.statusId.trim()
+          : undefined;
+    const projectId =
+      data.projectId === null
+        ? null
+        : data.projectId !== undefined
+          ? data.projectId.trim()
+          : undefined;
+
+    if (!title) {
+      return standardiseResponse({
+        message: "title is required",
+        httpStatus: 400,
+      });
+    }
+
+    if (!creatorId) {
+      return standardiseResponse({
+        message: "creatorId is required",
+        httpStatus: 400,
+      });
+    }
+
+    if (
+      data.description !== undefined &&
+      description !== null &&
+      !description
+    ) {
+      return standardiseResponse({
+        message: "description cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.parentId !== undefined && parentId !== null && !parentId) {
+      return standardiseResponse({
+        message: "parentId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.priorityId !== undefined && priorityId !== null && !priorityId) {
+      return standardiseResponse({
+        message: "priorityId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.statusId !== undefined && statusId !== null && !statusId) {
+      return standardiseResponse({
+        message: "statusId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.projectId !== undefined && projectId !== null && !projectId) {
+      return standardiseResponse({
+        message: "projectId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    const startDate =
+      data.startDate !== undefined && data.startDate !== null
+        ? new Date(data.startDate)
+        : data.startDate;
+    const dueDate =
+      data.dueDate !== undefined && data.dueDate !== null
+        ? new Date(data.dueDate)
+        : data.dueDate;
+
+    if (startDate instanceof Date && Number.isNaN(startDate.getTime())) {
+      return standardiseResponse({
+        message: "startDate must be a valid date",
+        httpStatus: 400,
+      });
+    }
+
+    if (dueDate instanceof Date && Number.isNaN(dueDate.getTime())) {
+      return standardiseResponse({
+        message: "dueDate must be a valid date",
+        httpStatus: 400,
+      });
+    }
+
+    if (
+      startDate instanceof Date &&
+      dueDate instanceof Date &&
+      dueDate.getTime() < startDate.getTime()
+    ) {
+      return standardiseResponse({
+        message: "dueDate cannot be before startDate",
+        httpStatus: 400,
+      });
+    }
+
+    if (
+      data.estimatedHours !== undefined &&
+      data.estimatedHours !== null &&
+      (!Number.isFinite(data.estimatedHours) || data.estimatedHours < 0)
+    ) {
+      return standardiseResponse({
+        message: "estimatedHours must be a non-negative number",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.isArchived !== undefined && typeof data.isArchived !== "boolean") {
+      return standardiseResponse({
+        message: "isArchived must be a boolean",
+        httpStatus: 400,
+      });
+    }
+
     try {
+      const creator = await prisma.user.findUnique({
+        where: { id: creatorId },
+      });
+
+      if (!creator) {
+        return standardiseResponse({
+          message: `User with ID ${creatorId} not found`,
+          httpStatus: 404,
+        });
+      }
+
+      if (parentId) {
+        const parent = await prisma.task.findUnique({
+          where: { id: parentId },
+        });
+        if (!parent) {
+          return standardiseResponse({
+            message: `Task with ID ${parentId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
+      if (priorityId) {
+        const priority = await prisma.priority.findUnique({
+          where: { id: priorityId },
+        });
+        if (!priority) {
+          return standardiseResponse({
+            message: `Priority with ID ${priorityId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
+      if (statusId) {
+        const status = await prisma.status.findUnique({
+          where: { id: statusId },
+        });
+        if (!status) {
+          return standardiseResponse({
+            message: `Status with ID ${statusId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
+      if (projectId) {
+        const project = await prisma.project.findUnique({
+          where: { id: projectId },
+        });
+        if (!project) {
+          return standardiseResponse({
+            message: `Project with ID ${projectId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
       const response = await prisma.task.create({
-        data,
+        data: {
+          title,
+          creatorId,
+          ...(description !== undefined ? { description } : {}),
+          ...(parentId !== undefined ? { parentId } : {}),
+          ...(priorityId !== undefined ? { priorityId } : {}),
+          ...(statusId !== undefined ? { statusId } : {}),
+          ...(projectId !== undefined ? { projectId } : {}),
+          ...(startDate !== undefined ? { startDate } : {}),
+          ...(dueDate !== undefined ? { dueDate } : {}),
+          ...(data.estimatedHours !== undefined
+            ? { estimatedHours: data.estimatedHours }
+            : {}),
+          ...(data.isArchived !== undefined
+            ? { isArchived: data.isArchived }
+            : {}),
+        },
         include: taskInclude,
       });
       return standardiseResponse({
@@ -65,6 +296,20 @@ export class TasksService {
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
+      if (isPrismaConflictError(error)) {
+        return standardiseResponse({
+          message: "Task already exists",
+          httpStatus: 409,
+        });
+      }
+
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: "Invalid reference while creating task",
+          httpStatus: 400,
+        });
+      }
+
       return standardiseResponse({
         message: "Error creating task",
         httpStatus: 500,
@@ -99,11 +344,263 @@ export class TasksService {
     }
   }
 
-  async update(id: string, data: TaskUpdateInput) {
+  async update(id: string, data: UpdateTaskInput) {
+    const title = data.title?.trim();
+    const creatorId =
+      data.creatorId !== undefined ? data.creatorId?.trim() : undefined;
+    const description =
+      data.description === null
+        ? null
+        : data.description !== undefined
+          ? data.description.trim()
+          : undefined;
+    const parentId =
+      data.parentId === null
+        ? null
+        : data.parentId !== undefined
+          ? data.parentId.trim()
+          : undefined;
+    const priorityId =
+      data.priorityId === null
+        ? null
+        : data.priorityId !== undefined
+          ? data.priorityId.trim()
+          : undefined;
+    const statusId =
+      data.statusId === null
+        ? null
+        : data.statusId !== undefined
+          ? data.statusId.trim()
+          : undefined;
+    const projectId =
+      data.projectId === null
+        ? null
+        : data.projectId !== undefined
+          ? data.projectId.trim()
+          : undefined;
+
+    const hasAnyUpdateField =
+      data.title !== undefined ||
+      data.description !== undefined ||
+      data.parentId !== undefined ||
+      data.creatorId !== undefined ||
+      data.priorityId !== undefined ||
+      data.statusId !== undefined ||
+      data.projectId !== undefined ||
+      data.startDate !== undefined ||
+      data.dueDate !== undefined ||
+      data.estimatedHours !== undefined ||
+      data.isArchived !== undefined;
+
+    if (!hasAnyUpdateField) {
+      return standardiseResponse({
+        message: "At least one field is required to update a task",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.title !== undefined && !title) {
+      return standardiseResponse({
+        message: "title cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (
+      data.description !== undefined &&
+      description !== null &&
+      !description
+    ) {
+      return standardiseResponse({
+        message: "description cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.creatorId !== undefined && !creatorId) {
+      return standardiseResponse({
+        message: "creatorId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.parentId !== undefined && parentId !== null && !parentId) {
+      return standardiseResponse({
+        message: "parentId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.priorityId !== undefined && priorityId !== null && !priorityId) {
+      return standardiseResponse({
+        message: "priorityId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.statusId !== undefined && statusId !== null && !statusId) {
+      return standardiseResponse({
+        message: "statusId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.projectId !== undefined && projectId !== null && !projectId) {
+      return standardiseResponse({
+        message: "projectId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
+    const startDate =
+      data.startDate !== undefined && data.startDate !== null
+        ? new Date(data.startDate)
+        : data.startDate;
+    const dueDate =
+      data.dueDate !== undefined && data.dueDate !== null
+        ? new Date(data.dueDate)
+        : data.dueDate;
+
+    if (startDate instanceof Date && Number.isNaN(startDate.getTime())) {
+      return standardiseResponse({
+        message: "startDate must be a valid date",
+        httpStatus: 400,
+      });
+    }
+
+    if (dueDate instanceof Date && Number.isNaN(dueDate.getTime())) {
+      return standardiseResponse({
+        message: "dueDate must be a valid date",
+        httpStatus: 400,
+      });
+    }
+
+    if (
+      startDate instanceof Date &&
+      dueDate instanceof Date &&
+      dueDate.getTime() < startDate.getTime()
+    ) {
+      return standardiseResponse({
+        message: "dueDate cannot be before startDate",
+        httpStatus: 400,
+      });
+    }
+
+    if (
+      data.estimatedHours !== undefined &&
+      data.estimatedHours !== null &&
+      (!Number.isFinite(data.estimatedHours) || data.estimatedHours < 0)
+    ) {
+      return standardiseResponse({
+        message: "estimatedHours must be a non-negative number",
+        httpStatus: 400,
+      });
+    }
+
+    if (data.isArchived !== undefined && typeof data.isArchived !== "boolean") {
+      return standardiseResponse({
+        message: "isArchived must be a boolean",
+        httpStatus: 400,
+      });
+    }
+
     try {
+      const existing = await prisma.task.findUnique({ where: { id } });
+
+      if (!existing) {
+        return standardiseResponse({
+          message: `Task with ID ${id} not found`,
+          httpStatus: 404,
+        });
+      }
+
+      if (creatorId) {
+        const creator = await prisma.user.findUnique({
+          where: { id: creatorId },
+        });
+
+        if (!creator) {
+          return standardiseResponse({
+            message: `User with ID ${creatorId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
+      if (parentId) {
+        if (parentId === id) {
+          return standardiseResponse({
+            message: "parentId cannot be the same as task id",
+            httpStatus: 400,
+          });
+        }
+
+        const parentTask = await prisma.task.findUnique({
+          where: { id: parentId },
+        });
+        if (!parentTask) {
+          return standardiseResponse({
+            message: `Task with ID ${parentId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
+      if (priorityId) {
+        const priority = await prisma.priority.findUnique({
+          where: { id: priorityId },
+        });
+        if (!priority) {
+          return standardiseResponse({
+            message: `Priority with ID ${priorityId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
+      if (statusId) {
+        const status = await prisma.status.findUnique({
+          where: { id: statusId },
+        });
+        if (!status) {
+          return standardiseResponse({
+            message: `Status with ID ${statusId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
+      if (projectId) {
+        const project = await prisma.project.findUnique({
+          where: { id: projectId },
+        });
+        if (!project) {
+          return standardiseResponse({
+            message: `Project with ID ${projectId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
       const response = await prisma.task.update({
         where: { id },
-        data,
+        data: {
+          ...(title !== undefined ? { title } : {}),
+          ...(description !== undefined ? { description } : {}),
+          ...(creatorId !== undefined ? { creatorId } : {}),
+          ...(parentId !== undefined ? { parentId } : {}),
+          ...(priorityId !== undefined ? { priorityId } : {}),
+          ...(statusId !== undefined ? { statusId } : {}),
+          ...(projectId !== undefined ? { projectId } : {}),
+          ...(startDate !== undefined ? { startDate } : {}),
+          ...(dueDate !== undefined ? { dueDate } : {}),
+          ...(data.estimatedHours !== undefined
+            ? { estimatedHours: data.estimatedHours }
+            : {}),
+          ...(data.isArchived !== undefined
+            ? { isArchived: data.isArchived }
+            : {}),
+        },
         include: taskInclude,
       });
       return standardiseResponse({
@@ -112,6 +609,20 @@ export class TasksService {
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
+      if (isPrismaConflictError(error)) {
+        return standardiseResponse({
+          message: "Task already exists",
+          httpStatus: 409,
+        });
+      }
+
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: "Invalid reference while updating task",
+          httpStatus: 400,
+        });
+      }
+
       return standardiseResponse({
         message: `Error updating task with ID ${id}`,
         httpStatus: 500,
@@ -122,12 +633,27 @@ export class TasksService {
 
   async delete(id: string) {
     try {
+      const existing = await prisma.task.findUnique({ where: { id } });
+      if (!existing) {
+        return standardiseResponse({
+          message: `Task with ID ${id} not found`,
+          httpStatus: 404,
+        });
+      }
+
       await prisma.task.delete({ where: { id } });
       return standardiseResponse({
         message: `Delete task with ID: ${id}`,
         httpStatus: 200,
       });
     } catch (error) {
+      if (isPrismaNotFoundError(error)) {
+        return standardiseResponse({
+          message: `Task with ID ${id} not found`,
+          httpStatus: 404,
+        });
+      }
+
       return standardiseResponse({
         message: `Error deleting task with ID ${id}`,
         httpStatus: 500,
@@ -137,12 +663,79 @@ export class TasksService {
   }
 
   async addLabels(taskId: string, labelIds: string[]) {
+    if (!Array.isArray(labelIds) || labelIds.length === 0) {
+      return standardiseResponse({
+        message: "labelIds must be a non-empty array",
+        httpStatus: 400,
+      });
+    }
+
+    const normalizedLabelIds = labelIds.map((id) => id?.trim());
+    if (normalizedLabelIds.some((id) => !id)) {
+      return standardiseResponse({
+        message: "labelIds must contain only non-empty strings",
+        httpStatus: 400,
+      });
+    }
+
+    const uniqueLabelIds = [...new Set(normalizedLabelIds)] as string[];
+
     try {
+      const task = await prisma.task.findUnique({ where: { id: taskId } });
+      if (!task) {
+        return standardiseResponse({
+          message: `Task with ID ${taskId} not found`,
+          httpStatus: 404,
+        });
+      }
+
+      const existingLabels = await prisma.label.findMany({
+        where: {
+          id: {
+            in: uniqueLabelIds,
+          },
+        },
+        select: { id: true },
+      });
+
+      const existingLabelIdSet = new Set(
+        existingLabels.map((label) => label.id),
+      );
+      const missingLabelIds = uniqueLabelIds.filter(
+        (labelId) => !existingLabelIdSet.has(labelId),
+      );
+
+      if (missingLabelIds.length > 0) {
+        return standardiseResponse({
+          message: `Labels not found: ${missingLabelIds.join(", ")}`,
+          httpStatus: 404,
+        });
+      }
+
+      const existingLinks = await prisma.taskLabel.findMany({
+        where: {
+          taskId,
+          labelId: {
+            in: uniqueLabelIds,
+          },
+        },
+        select: { labelId: true },
+      });
+
+      if (existingLinks.length > 0) {
+        return standardiseResponse({
+          message: `Labels already assigned to task ${taskId}: ${existingLinks
+            .map((link) => link.labelId)
+            .join(", ")}`,
+          httpStatus: 409,
+        });
+      }
+
       const response = await prisma.task.update({
         where: { id: taskId },
         data: {
           labelLinks: {
-            create: labelIds.map((id) => ({
+            create: uniqueLabelIds.map((id) => ({
               label: {
                 connect: { id },
               },
@@ -157,6 +750,27 @@ export class TasksService {
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
+      if (isPrismaConflictError(error)) {
+        return standardiseResponse({
+          message: "One or more labels are already assigned to this task",
+          httpStatus: 409,
+        });
+      }
+
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: `Invalid reference while adding labels to task ${taskId}`,
+          httpStatus: 400,
+        });
+      }
+
+      if (isPrismaNotFoundError(error)) {
+        return standardiseResponse({
+          message: `Task with ID ${taskId} not found`,
+          httpStatus: 404,
+        });
+      }
+
       return standardiseResponse({
         message: `Error adding labels to task ${taskId}`,
         httpStatus: 500,
@@ -166,14 +780,39 @@ export class TasksService {
   }
 
   async removeLabels(taskId: string, labelIds: string[]) {
+    if (!Array.isArray(labelIds) || labelIds.length === 0) {
+      return standardiseResponse({
+        message: "labelIds must be a non-empty array",
+        httpStatus: 400,
+      });
+    }
+
+    const normalizedLabelIds = labelIds.map((id) => id?.trim());
+    if (normalizedLabelIds.some((id) => !id)) {
+      return standardiseResponse({
+        message: "labelIds must contain only non-empty strings",
+        httpStatus: 400,
+      });
+    }
+
+    const uniqueLabelIds = [...new Set(normalizedLabelIds)] as string[];
+
     try {
+      const task = await prisma.task.findUnique({ where: { id: taskId } });
+      if (!task) {
+        return standardiseResponse({
+          message: `Task with ID ${taskId} not found`,
+          httpStatus: 404,
+        });
+      }
+
       const response = await prisma.task.update({
         where: { id: taskId },
         data: {
           labelLinks: {
             deleteMany: {
               labelId: {
-                in: labelIds,
+                in: uniqueLabelIds,
               },
             },
           },
@@ -186,6 +825,13 @@ export class TasksService {
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
+      if (isPrismaNotFoundError(error)) {
+        return standardiseResponse({
+          message: `Task with ID ${taskId} not found`,
+          httpStatus: 404,
+        });
+      }
+
       return standardiseResponse({
         message: `Error removing labels from task ${taskId}`,
         httpStatus: 500,
@@ -195,12 +841,48 @@ export class TasksService {
   }
 
   async setPriority(taskId: string, priorityId: string | null) {
+    if (priorityId === undefined) {
+      return standardiseResponse({
+        message: "priorityId is required",
+        httpStatus: 400,
+      });
+    }
+
+    const normalizedPriorityId = priorityId === null ? null : priorityId.trim();
+
+    if (priorityId !== null && !normalizedPriorityId) {
+      return standardiseResponse({
+        message: "priorityId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
     try {
+      const task = await prisma.task.findUnique({ where: { id: taskId } });
+      if (!task) {
+        return standardiseResponse({
+          message: `Task with ID ${taskId} not found`,
+          httpStatus: 404,
+        });
+      }
+
+      if (normalizedPriorityId) {
+        const priority = await prisma.priority.findUnique({
+          where: { id: normalizedPriorityId },
+        });
+        if (!priority) {
+          return standardiseResponse({
+            message: `Priority with ID ${normalizedPriorityId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
       const response = await prisma.task.update({
         where: { id: taskId },
         data: {
-          priority: priorityId
-            ? { connect: { id: priorityId } }
+          priority: normalizedPriorityId
+            ? { connect: { id: normalizedPriorityId } }
             : { disconnect: true },
         },
         include: taskInclude,
@@ -211,6 +893,20 @@ export class TasksService {
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
+      if (isPrismaNotFoundError(error)) {
+        return standardiseResponse({
+          message: `Task with ID ${taskId} not found`,
+          httpStatus: 404,
+        });
+      }
+
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: `Invalid priority reference for task ${taskId}`,
+          httpStatus: 400,
+        });
+      }
+
       return standardiseResponse({
         message: `Error setting priority for task ${taskId}`,
         httpStatus: 500,
@@ -220,12 +916,48 @@ export class TasksService {
   }
 
   async setStatus(taskId: string, statusId: string | null) {
+    if (statusId === undefined) {
+      return standardiseResponse({
+        message: "statusId is required",
+        httpStatus: 400,
+      });
+    }
+
+    const normalizedStatusId = statusId === null ? null : statusId.trim();
+
+    if (statusId !== null && !normalizedStatusId) {
+      return standardiseResponse({
+        message: "statusId cannot be empty",
+        httpStatus: 400,
+      });
+    }
+
     try {
+      const task = await prisma.task.findUnique({ where: { id: taskId } });
+      if (!task) {
+        return standardiseResponse({
+          message: `Task with ID ${taskId} not found`,
+          httpStatus: 404,
+        });
+      }
+
+      if (normalizedStatusId) {
+        const status = await prisma.status.findUnique({
+          where: { id: normalizedStatusId },
+        });
+        if (!status) {
+          return standardiseResponse({
+            message: `Status with ID ${normalizedStatusId} not found`,
+            httpStatus: 404,
+          });
+        }
+      }
+
       const response = await prisma.task.update({
         where: { id: taskId },
         data: {
-          status: statusId
-            ? { connect: { id: statusId } }
+          status: normalizedStatusId
+            ? { connect: { id: normalizedStatusId } }
             : { disconnect: true },
         },
         include: taskInclude,
@@ -236,6 +968,20 @@ export class TasksService {
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
+      if (isPrismaNotFoundError(error)) {
+        return standardiseResponse({
+          message: `Task with ID ${taskId} not found`,
+          httpStatus: 404,
+        });
+      }
+
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: `Invalid status reference for task ${taskId}`,
+          httpStatus: 400,
+        });
+      }
+
       return standardiseResponse({
         message: `Error setting status for task ${taskId}`,
         httpStatus: 500,
@@ -245,8 +991,10 @@ export class TasksService {
   }
 
   async assignProject(taskId: string, projectId: string) {
+    const normalizedProjectId = projectId?.trim();
+
     try {
-      if (!projectId) {
+      if (!normalizedProjectId) {
         return standardiseResponse({
           message: "projectId is required",
           httpStatus: 400,
@@ -262,11 +1010,11 @@ export class TasksService {
       }
 
       const project = await prisma.project.findUnique({
-        where: { id: projectId },
+        where: { id: normalizedProjectId },
       });
       if (!project) {
         return standardiseResponse({
-          message: `Project with ID ${projectId} not found`,
+          message: `Project with ID ${normalizedProjectId} not found`,
           httpStatus: 404,
         });
       }
@@ -275,29 +1023,33 @@ export class TasksService {
         where: { id: taskId },
         data: {
           project: {
-            connect: { id: projectId },
+            connect: { id: normalizedProjectId },
           },
         },
         include: taskInclude,
       });
       return standardiseResponse({
-        message: `Assign project ${projectId} to task ${taskId}`,
+        message: `Assign project ${normalizedProjectId} to task ${taskId}`,
         httpStatus: 200,
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Record to update not found")
-      ) {
+      if (isPrismaNotFoundError(error)) {
         return standardiseResponse({
           message: `Task with ID ${taskId} not found`,
           httpStatus: 404,
         });
       }
 
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: `Invalid project reference for task ${taskId}`,
+          httpStatus: 400,
+        });
+      }
+
       return standardiseResponse({
-        message: `Error assigning project ${projectId} to task ${taskId}`,
+        message: `Error assigning project ${normalizedProjectId} to task ${taskId}`,
         httpStatus: 500,
         error,
       });
@@ -329,10 +1081,7 @@ export class TasksService {
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Record to update not found")
-      ) {
+      if (isPrismaNotFoundError(error)) {
         return standardiseResponse({
           message: `Task with ID ${taskId} not found`,
           httpStatus: 404,
@@ -349,6 +1098,14 @@ export class TasksService {
 
   async archive(id: string) {
     try {
+      const task = await prisma.task.findUnique({ where: { id } });
+      if (!task) {
+        return standardiseResponse({
+          message: `Task with ID ${id} not found`,
+          httpStatus: 404,
+        });
+      }
+
       const response = await prisma.task.update({
         where: { id },
         data: { isArchived: true },
@@ -360,16 +1117,31 @@ export class TasksService {
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
+      if (isPrismaNotFoundError(error)) {
+        return standardiseResponse({
+          message: `Task with ID ${id} not found`,
+          httpStatus: 404,
+        });
+      }
+
       return standardiseResponse({
         message: `Error archiving task with ID ${id}`,
         httpStatus: 500,
-        error: error,
+        error,
       });
     }
   }
 
   async unarchive(id: string) {
     try {
+      const task = await prisma.task.findUnique({ where: { id } });
+      if (!task) {
+        return standardiseResponse({
+          message: `Task with ID ${id} not found`,
+          httpStatus: 404,
+        });
+      }
+
       const response = await prisma.task.update({
         where: { id },
         data: { isArchived: false },
@@ -381,17 +1153,26 @@ export class TasksService {
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
+      if (isPrismaNotFoundError(error)) {
+        return standardiseResponse({
+          message: `Task with ID ${id} not found`,
+          httpStatus: 404,
+        });
+      }
+
       return standardiseResponse({
         message: `Error unarchiving task with ID ${id}`,
         httpStatus: 500,
-        error: error,
+        error,
       });
     }
   }
 
   async assignUser(taskId: string, userId: string) {
+    const normalizedUserId = userId?.trim();
+
     try {
-      if (!userId) {
+      if (!normalizedUserId) {
         return standardiseResponse({
           message: "userId is required",
           httpStatus: 400,
@@ -407,11 +1188,11 @@ export class TasksService {
       }
 
       const user = await prisma.user.findUnique({
-        where: { id: userId },
+        where: { id: normalizedUserId },
       });
       if (!user) {
         return standardiseResponse({
-          message: `User with ID ${userId} not found`,
+          message: `User with ID ${normalizedUserId} not found`,
           httpStatus: 404,
         });
       }
@@ -420,29 +1201,40 @@ export class TasksService {
         where: { id: taskId },
         data: {
           assignees: {
-            connect: { userId_taskId: { userId, taskId } },
+            connect: { userId_taskId: { userId: normalizedUserId, taskId } },
           },
         },
         include: taskInclude,
       });
       return standardiseResponse({
-        message: `Assign user ${userId} to task ${taskId}`,
+        message: `Assign user ${normalizedUserId} to task ${taskId}`,
         httpStatus: 200,
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Record to update not found")
-      ) {
+      if (isPrismaConflictError(error)) {
+        return standardiseResponse({
+          message: `User ${normalizedUserId} is already assigned to task ${taskId}`,
+          httpStatus: 409,
+        });
+      }
+
+      if (isPrismaNotFoundError(error)) {
         return standardiseResponse({
           message: `Task with ID ${taskId} not found`,
           httpStatus: 404,
         });
       }
 
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: `Invalid user reference while assigning to task ${taskId}`,
+          httpStatus: 400,
+        });
+      }
+
       return standardiseResponse({
-        message: `Error assigning user ${userId} to task ${taskId}`,
+        message: `Error assigning user ${normalizedUserId} to task ${taskId}`,
         httpStatus: 500,
         error,
       });
@@ -450,6 +1242,15 @@ export class TasksService {
   }
 
   async unassignUser(taskId: string, userId: string) {
+    const normalizedUserId = userId?.trim();
+
+    if (!normalizedUserId) {
+      return standardiseResponse({
+        message: "userId is required",
+        httpStatus: 400,
+      });
+    }
+
     try {
       const task = await prisma.task.findUnique({ where: { id: taskId } });
       if (!task) {
@@ -460,11 +1261,11 @@ export class TasksService {
       }
 
       const user = await prisma.user.findUnique({
-        where: { id: userId },
+        where: { id: normalizedUserId },
       });
       if (!user) {
         return standardiseResponse({
-          message: `User with ID ${userId} not found`,
+          message: `User with ID ${normalizedUserId} not found`,
           httpStatus: 404,
         });
       }
@@ -473,21 +1274,18 @@ export class TasksService {
         where: { id: taskId },
         data: {
           assignees: {
-            disconnect: { userId_taskId: { userId, taskId } },
+            disconnect: { userId_taskId: { userId: normalizedUserId, taskId } },
           },
         },
         include: taskInclude,
       });
       return standardiseResponse({
-        message: `Unassign user ${userId} from task ${taskId}`,
+        message: `Unassign user ${normalizedUserId} from task ${taskId}`,
         httpStatus: 200,
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Record to update not found")
-      ) {
+      if (isPrismaNotFoundError(error)) {
         return standardiseResponse({
           message: `Task with ID ${taskId} not found`,
           httpStatus: 404,
@@ -495,7 +1293,7 @@ export class TasksService {
       }
 
       return standardiseResponse({
-        message: `Error unassigning user ${userId} from task ${taskId}`,
+        message: `Error unassigning user ${normalizedUserId} from task ${taskId}`,
         httpStatus: 500,
         error,
       });
@@ -503,8 +1301,10 @@ export class TasksService {
   }
 
   async watchTask(taskId: string, userId: string) {
+    const normalizedUserId = userId?.trim();
+
     try {
-      if (!userId) {
+      if (!normalizedUserId) {
         return standardiseResponse({
           message: "userId is required",
           httpStatus: 400,
@@ -520,11 +1320,11 @@ export class TasksService {
       }
 
       const user = await prisma.user.findUnique({
-        where: { id: userId },
+        where: { id: normalizedUserId },
       });
       if (!user) {
         return standardiseResponse({
-          message: `User with ID ${userId} not found`,
+          message: `User with ID ${normalizedUserId} not found`,
           httpStatus: 404,
         });
       }
@@ -533,30 +1333,41 @@ export class TasksService {
         where: { id: taskId },
         data: {
           watchers: {
-            connect: { userId_taskId: { userId, taskId } },
+            connect: { userId_taskId: { userId: normalizedUserId, taskId } },
           },
         },
         include: taskInclude,
       });
 
       return standardiseResponse({
-        message: `Watch task ${taskId} as user ${userId}`,
+        message: `Watch task ${taskId} as user ${normalizedUserId}`,
         httpStatus: 200,
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Record to update not found")
-      ) {
+      if (isPrismaConflictError(error)) {
+        return standardiseResponse({
+          message: `User ${normalizedUserId} is already watching task ${taskId}`,
+          httpStatus: 409,
+        });
+      }
+
+      if (isPrismaNotFoundError(error)) {
         return standardiseResponse({
           message: `Task with ID ${taskId} not found`,
           httpStatus: 404,
         });
       }
 
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: `Invalid user reference while watching task ${taskId}`,
+          httpStatus: 400,
+        });
+      }
+
       return standardiseResponse({
-        message: `Error watching task ${taskId} as user ${userId}`,
+        message: `Error watching task ${taskId} as user ${normalizedUserId}`,
         httpStatus: 500,
         error,
       });
@@ -564,8 +1375,10 @@ export class TasksService {
   }
 
   async unwatchTask(taskId: string, userId: string) {
+    const normalizedUserId = userId?.trim();
+
     try {
-      if (!userId) {
+      if (!normalizedUserId) {
         return standardiseResponse({
           message: "userId is required",
           httpStatus: 400,
@@ -581,11 +1394,11 @@ export class TasksService {
       }
 
       const user = await prisma.user.findUnique({
-        where: { id: userId },
+        where: { id: normalizedUserId },
       });
       if (!user) {
         return standardiseResponse({
-          message: `User with ID ${userId} not found`,
+          message: `User with ID ${normalizedUserId} not found`,
           httpStatus: 404,
         });
       }
@@ -594,22 +1407,21 @@ export class TasksService {
         where: { id: taskId },
         data: {
           watchers: {
-            disconnect: { userId_taskId: { userId, taskId } },
+            disconnect: {
+              userId_taskId: { userId: normalizedUserId, taskId },
+            },
           },
         },
         include: taskInclude,
       });
 
       return standardiseResponse({
-        message: `Unwatch task ${taskId} as user ${userId}`,
+        message: `Unwatch task ${taskId} as user ${normalizedUserId}`,
         httpStatus: 200,
         data: normalizeTaskWithDetails(response),
       });
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.message.includes("Record to update not found")
-      ) {
+      if (isPrismaNotFoundError(error)) {
         return standardiseResponse({
           message: `Task with ID ${taskId} not found`,
           httpStatus: 404,
@@ -617,7 +1429,7 @@ export class TasksService {
       }
 
       return standardiseResponse({
-        message: `Error unwatching task ${taskId} as user ${userId}`,
+        message: `Error unwatching task ${taskId} as user ${normalizedUserId}`,
         httpStatus: 500,
         error,
       });


### PR DESCRIPTION
## Summary
- revise tasks service with consistent validation, defensive checks, and normalized relation handling
- map Prisma conflict/foreign-key/not-found cases to consistent API responses across task operations
- add a dedicated tasks service unit test suite covering validation and regression scenarios

## Verification
- npm run lint
- npm run build
- npm run test

Closes #75