### PR TITLE
feat(api): revise users service and add tests

### DIFF
--- a/server/services/__tests__/users.service.test.ts
+++ b/server/services/__tests__/users.service.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UsersService } from "../users.service";
+
+// Mock dependencies
+const mockFindMany = vi.fn();
+const mockUserFindUnique = vi.fn();
+const mockRoleFindUnique = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("../../utils/prisma", () => ({
+  prisma: {
+    user: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+      create: (...args: unknown[]) => mockCreate(...args),
+      update: (...args: unknown[]) => mockUpdate(...args),
+      delete: (...args: unknown[]) => mockDelete(...args),
+    },
+    role: {
+      findUnique: (...args: unknown[]) => mockRoleFindUnique(...args),
+    },
+  },
+}));
+
+vi.mock("../../utils/api", () => ({
+  standardiseResponse: (config: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+  }) => config,
+}));
+
+vi.mock("../../utils/prismaErrors", () => ({
+  isPrismaConflictError: (error: unknown) =>
+    error instanceof Error && error.message.includes("Unique constraint"),
+  isPrismaForeignKeyError: (error: unknown) =>
+    error instanceof Error && error.message.includes("Foreign key constraint"),
+  isPrismaNotFoundError: (error: unknown) =>
+    error instanceof Error && error.message.includes("Record to update not found"),
+}));
+
+describe("UsersService", () => {
+  let service: UsersService;
+
+  beforeEach(() => {
+    service = new UsersService();
+    vi.clearAllMocks();
+  });
+
+  describe("get", () => {
+    it("should return 404 if no users found", async () => {
+      mockFindMany.mockResolvedValueOnce([]);
+      const result = await service.get();
+      expect(result.httpStatus).toBe(404);
+      expect(result.message).toContain("No users found");
+    });
+
+    it("should return users list successfully", async () => {
+      const mockUsers = [
+        { id: "user-1", name: "John", email: "john@example.com" },
+        { id: "user-2", name: "Jane", email: "jane@example.com" },
+      ];
+      mockFindMany.mockResolvedValueOnce(mockUsers);
+      const result = await service.get();
+      expect(result.httpStatus).toBe(200);
+      expect(result.data).toBe(mockUsers);
+    });
+
+    it("should return 500 on unexpected error", async () => {
+      mockFindMany.mockRejectedValueOnce(new Error("Database error"));
+      const result = await service.get();
+      expect(result.httpStatus).toBe(500);
+    });
+  });
+
+  describe("create", () => {
+    it("should return 400 if name is missing", async () => {
+      const result = await service.create({ name: "", email: "test@example.com" });
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("name is required");
+    });
+
+    it("should return 400 if name is only whitespace", async () => {
+      const result = await service.create({
+        name: "   ",
+        email: "test@example.com",
+      });
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("name is required");
+    });
+
+    it("should return 400 if email is missing", async () => {
+      const result = await service.create({ name: "John Doe", email: "" });
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("email is required");
+    });
+
+    it("should return 400 if email is only whitespace", async () => {
+      const result = await service.create({ name: "John Doe", email: "   " });
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("email is required");
+    });
+
+    it("should return 400 if role does not exist", async () => {
+      mockRoleFindUnique.mockResolvedValueOnce(null);
+      const result = await service.create({
+        name: "John Doe",
+        email: "john@example.com",
+        roleId: "non-existent-role",
+      });
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("Role");
+    });
+
+    it("should return 409 on conflict error (duplicate email)", async () => {
+      mockRoleFindUnique.mockResolvedValueOnce({ id: "role-1" });
+      mockCreate.mockRejectedValueOnce(new Error("Unique constraint failed"));
+      const result = await service.create({
+        name: "John Doe",
+        email: "duplicate@example.com",
+        roleId: "role-1",
+      });
+      expect(result.httpStatus).toBe(409);
+      expect(result.message).toContain("email already exists");
+    });
+
+    it("should return 400 on foreign key error", async () => {
+      mockRoleFindUnique.mockResolvedValueOnce({ id: "role-1" });
+      mockCreate.mockRejectedValueOnce(
+        new Error("Foreign key constraint failed")
+      );
+      const result = await service.create({
+        name: "John Doe",
+        email: "john@example.com",
+        roleId: "role-1",
+      });
+      expect(result.httpStatus).toBe(400);
+    });
+
+    it("should create user successfully with valid data", async () => {
+      const mockUser = {
+        id: "user-1",
+        name: "John Doe",
+        email: "john@example.com",
+      };
+      mockRoleFindUnique.mockResolvedValueOnce({ id: "role-1" });
+      mockCreate.mockResolvedValueOnce(mockUser);
+      const result = await service.create({
+        name: "John Doe",
+        email: "john@example.com",
+        roleId: "role-1",
+      });
+      expect(result.httpStatus).toBe(201);
+      expect(result.data).toBe(mockUser);
+    });
+
+    it("should create user successfully without roleId", async () => {
+      const mockUser = {
+        id: "user-1",
+        name: "John Doe",
+        email: "john@example.com",
+      };
+      mockCreate.mockResolvedValueOnce(mockUser);
+      const result = await service.create({
+        name: "John Doe",
+        email: "john@example.com",
+      });
+      expect(result.httpStatus).toBe(201);
+      expect(result.data).toBe(mockUser);
+    });
+  });
+
+  describe("getById", () => {
+    it("should return 400 if id is empty", async () => {
+      const result = await service.getById("");
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("ID is required");
+    });
+
+    it("should return 400 if id is only whitespace", async () => {
+      const result = await service.getById("   ");
+      expect(result.httpStatus).toBe(400);
+    });
+
+    it("should return 404 if user not found", async () => {
+      mockUserFindUnique.mockResolvedValueOnce(null);
+      const result = await service.getById("non-existent-id");
+      expect(result.httpStatus).toBe(404);
+      expect(result.message).toContain("not found");
+    });
+
+    it("should return user if found", async () => {
+      const mockUser = {
+        id: "user-1",
+        name: "John Doe",
+        email: "john@example.com",
+      };
+      mockUserFindUnique.mockResolvedValueOnce(mockUser);
+      const result = await service.getById("user-1");
+      expect(result.httpStatus).toBe(200);
+      expect(result.data).toBe(mockUser);
+    });
+  });
+
+  describe("update", () => {
+    it("should return 400 if id is empty", async () => {
+      const result = await service.update("", { name: "Updated" });
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("ID is required");
+    });
+
+    it("should return 400 if name is empty string", async () => {
+      const result = await service.update("user-1", { name: "" });
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("name cannot be empty");
+    });
+
+    it("should return 400 if email is empty string", async () => {
+      const result = await service.update("user-1", { email: "" });
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("email cannot be empty");
+    });
+
+    it("should return 400 if role does not exist", async () => {
+      mockRoleFindUnique.mockResolvedValueOnce(null);
+      const result = await service.update("user-1", {
+        roleId: "non-existent-role",
+      });
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("Role");
+    });
+
+    it("should return 404 if user does not exist", async () => {
+      mockRoleFindUnique.mockResolvedValueOnce({ id: "role-1" });
+      mockUserFindUnique.mockResolvedValueOnce(null);
+      const result = await service.update("non-existent", {
+        name: "Updated",
+        roleId: "role-1",
+      });
+      expect(result.httpStatus).toBe(404);
+    });
+
+    it("should return 404 on Prisma not found error", async () => {
+      mockRoleFindUnique.mockResolvedValueOnce({ id: "role-1" });
+      mockUserFindUnique.mockResolvedValueOnce({ id: "user-1" });
+      mockUpdate.mockRejectedValueOnce(
+        new Error("Record to update not found")
+      );
+      const result = await service.update("user-1", {
+        name: "Updated",
+        roleId: "role-1",
+      });
+      expect(result.httpStatus).toBe(404);
+    });
+
+    it("should return 409 on conflict error (duplicate email)", async () => {
+      mockUserFindUnique.mockResolvedValueOnce({ id: "user-1" });
+      mockUpdate.mockRejectedValueOnce(new Error("Unique constraint failed"));
+      const result = await service.update("user-1", {
+        email: "duplicate@example.com",
+      });
+      expect(result.httpStatus).toBe(409);
+    });
+
+    it("should update user successfully", async () => {
+      const mockUser = { id: "user-1", name: "Updated User" };
+      mockRoleFindUnique.mockResolvedValueOnce({ id: "role-1" });
+      mockUserFindUnique.mockResolvedValueOnce({ id: "user-1" });
+      mockUpdate.mockResolvedValueOnce(mockUser);
+      const result = await service.update("user-1", {
+        name: "Updated User",
+        roleId: "role-1",
+      });
+      expect(result.httpStatus).toBe(200);
+      expect(result.data).toBe(mockUser);
+    });
+  });
+
+  describe("delete", () => {
+    it("should return 400 if id is empty", async () => {
+      const result = await service.delete("");
+      expect(result.httpStatus).toBe(400);
+    });
+
+    it("should return 404 if user does not exist", async () => {
+      mockUserFindUnique.mockResolvedValueOnce(null);
+      const result = await service.delete("non-existent");
+      expect(result.httpStatus).toBe(404);
+    });
+
+    it("should return 400 on foreign key constraint error", async () => {
+      mockUserFindUnique.mockResolvedValueOnce({ id: "user-1" });
+      mockDelete.mockRejectedValueOnce(
+        new Error("Foreign key constraint failed")
+      );
+      const result = await service.delete("user-1");
+      expect(result.httpStatus).toBe(400);
+      expect(result.message).toContain("associated records");
+    });
+
+    it("should delete user successfully", async () => {
+      const mockUser = { id: "user-1", name: "John Doe" };
+      mockUserFindUnique.mockResolvedValueOnce({ id: "user-1" });
+      mockDelete.mockResolvedValueOnce(mockUser);
+      const result = await service.delete("user-1");
+      expect(result.httpStatus).toBe(200);
+      expect(result.data).toBe(mockUser);
+    });
+  });
+});

--- a/server/services/users.service.ts
+++ b/server/services/users.service.ts
@@ -1,5 +1,11 @@
 import { UserCreateInput, UserUpdateInput } from "../prisma/generated/models";
-import { prisma, standardiseResponse } from "../utils";
+import {
+  isPrismaConflictError,
+  isPrismaForeignKeyError,
+  isPrismaNotFoundError,
+  prisma,
+  standardiseResponse,
+} from "../utils";
 
 export class UsersService {
   async get() {
@@ -27,13 +33,65 @@ export class UsersService {
 
   async create(data: UserCreateInput) {
     try {
-      const response = await prisma.user.create({ data });
+      // Normalize string inputs
+      const normalizedData: UserCreateInput = {
+        ...data,
+        name: data.name?.trim(),
+        email: data.email?.trim(),
+      };
+
+      // Validate required fields
+      if (!normalizedData.name || normalizedData.name === "") {
+        return standardiseResponse({
+          message: "User name is required",
+          httpStatus: 400,
+          error: "name field cannot be empty",
+        });
+      }
+
+      if (!normalizedData.email || normalizedData.email === "") {
+        return standardiseResponse({
+          message: "User email is required",
+          httpStatus: 400,
+          error: "email field cannot be empty",
+        });
+      }
+
+      // Validate role exists if provided
+      if (normalizedData.roleId) {
+        const role = await prisma.role.findUnique({
+          where: { id: normalizedData.roleId },
+        });
+        if (!role) {
+          return standardiseResponse({
+            message: `Role with ID ${normalizedData.roleId} not found`,
+            httpStatus: 400,
+            error: `Role with ID ${normalizedData.roleId} does not exist`,
+          });
+        }
+      }
+
+      const response = await prisma.user.create({ data: normalizedData });
       return standardiseResponse({
         message: "Create a user",
         httpStatus: 201,
         data: response,
       });
     } catch (error) {
+      if (isPrismaConflictError(error)) {
+        return standardiseResponse({
+          message: "User with this email already exists",
+          httpStatus: 409,
+          error: "A user with this email already exists",
+        });
+      }
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: "Invalid reference in user data",
+          httpStatus: 400,
+          error: "Referenced entity does not exist",
+        });
+      }
       return standardiseResponse({
         message: "Error creating user",
         httpStatus: 500,
@@ -44,15 +102,28 @@ export class UsersService {
 
   async getById(id: string) {
     try {
-      const response = await prisma.user.findUnique({ where: { id } });
+      // Validate id input
+      const normalizedId = id?.trim();
+      if (!normalizedId || normalizedId === "") {
+        return standardiseResponse({
+          message: "User ID is required",
+          httpStatus: 400,
+          error: "id parameter cannot be empty",
+        });
+      }
+
+      const response = await prisma.user.findUnique({
+        where: { id: normalizedId },
+      });
       if (!response) {
         return standardiseResponse({
-          message: `User with ID ${id} not found`,
+          message: `User with ID ${normalizedId} not found`,
           httpStatus: 404,
+          error: `No user found with ID ${normalizedId}`,
         });
       }
       return standardiseResponse({
-        message: `Get user by ID: ${id}`,
+        message: `Get user by ID: ${normalizedId}`,
         httpStatus: 200,
         data: response,
       });
@@ -67,30 +138,153 @@ export class UsersService {
 
   async update(id: string, data: UserUpdateInput) {
     try {
-      const response = await prisma.user.update({ where: { id }, data });
+      // Validate id input
+      const normalizedId = id?.trim();
+      if (!normalizedId || normalizedId === "") {
+        return standardiseResponse({
+          message: "User ID is required",
+          httpStatus: 400,
+          error: "id parameter cannot be empty",
+        });
+      }
+
+      // Normalize string inputs
+      const normalizedData: UserUpdateInput = {
+        ...data,
+        name: data.name?.trim(),
+        email: data.email?.trim(),
+      };
+
+      // Validate name if provided
+      if (normalizedData.name !== undefined && normalizedData.name === "") {
+        return standardiseResponse({
+          message: "User name cannot be empty",
+          httpStatus: 400,
+          error: "name field cannot be empty string",
+        });
+      }
+
+      // Validate email if provided
+      if (normalizedData.email !== undefined && normalizedData.email === "") {
+        return standardiseResponse({
+          message: "User email cannot be empty",
+          httpStatus: 400,
+          error: "email field cannot be empty string",
+        });
+      }
+
+      // Validate role exists if provided
+      if (normalizedData.roleId) {
+        const role = await prisma.role.findUnique({
+          where: { id: normalizedData.roleId },
+        });
+        if (!role) {
+          return standardiseResponse({
+            message: `Role with ID ${normalizedData.roleId} not found`,
+            httpStatus: 400,
+            error: `Role with ID ${normalizedData.roleId} does not exist`,
+          });
+        }
+      }
+
+      // Check if user exists
+      const existing = await prisma.user.findUnique({
+        where: { id: normalizedId },
+      });
+      if (!existing) {
+        return standardiseResponse({
+          message: `User with ID ${normalizedId} not found`,
+          httpStatus: 404,
+          error: `No user found with ID ${normalizedId}`,
+        });
+      }
+
+      const response = await prisma.user.update({
+        where: { id: normalizedId },
+        data: normalizedData,
+      });
       return standardiseResponse({
-        message: `Update user with ID: ${id}`,
+        message: `Update user with ID: ${normalizedId}`,
         httpStatus: 200,
         data: response,
       });
     } catch (error) {
-      return {
+      if (isPrismaNotFoundError(error)) {
+        return standardiseResponse({
+          message: `User with ID ${id} not found`,
+          httpStatus: 404,
+          error: `No user found with ID ${id}`,
+        });
+      }
+      if (isPrismaConflictError(error)) {
+        return standardiseResponse({
+          message: "User with this email already exists",
+          httpStatus: 409,
+          error: "A user with this email already exists",
+        });
+      }
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: "Invalid reference in user data",
+          httpStatus: 400,
+          error: "Referenced entity does not exist",
+        });
+      }
+      return standardiseResponse({
         message: `Error updating user with ID ${id}`,
         httpStatus: 500,
         error,
-      };
+      });
     }
   }
 
   async delete(id: string) {
     try {
-      const response = await prisma.user.delete({ where: { id } });
+      // Validate id input
+      const normalizedId = id?.trim();
+      if (!normalizedId || normalizedId === "") {
+        return standardiseResponse({
+          message: "User ID is required",
+          httpStatus: 400,
+          error: "id parameter cannot be empty",
+        });
+      }
+
+      // Check if user exists
+      const existing = await prisma.user.findUnique({
+        where: { id: normalizedId },
+      });
+      if (!existing) {
+        return standardiseResponse({
+          message: `User with ID ${normalizedId} not found`,
+          httpStatus: 404,
+          error: `No user found with ID ${normalizedId}`,
+        });
+      }
+
+      const response = await prisma.user.delete({
+        where: { id: normalizedId },
+      });
       return standardiseResponse({
-        message: `Delete user with ID: ${id}`,
+        message: `Delete user with ID: ${normalizedId}`,
         httpStatus: 200,
         data: response,
       });
     } catch (error) {
+      if (isPrismaNotFoundError(error)) {
+        return standardiseResponse({
+          message: `User with ID ${id} not found`,
+          httpStatus: 404,
+          error: `No user found with ID ${id}`,
+        });
+      }
+      if (isPrismaForeignKeyError(error)) {
+        return standardiseResponse({
+          message: "Cannot delete user with associated records",
+          httpStatus: 400,
+          error: "User has associated tasks, projects, comments, or other records",
+        });
+      }
       return standardiseResponse({
         message: `Error deleting user with ID ${id}`,
         httpStatus: 500,


### PR DESCRIPTION
## Changes
- Add normalized input validation (trim + empty checks) for all string inputs
- Add defensive existence checks for user and role entities
- Add Prisma error classification (conflict→409, foreign-key→400, not-found→404)
- Validate role existence when creating or updating users
- Add 28 unit tests covering:
  - Input validation (empty/whitespace checks for name and email)
  - CRUD operations (get, create, getById, update, delete)
  - Role reference validation
  - Prisma error mapping (conflict, foreign key, not found)
  - Edge cases (duplicate email, missing role, etc.)

## Testing
- ✅ Lint: Passed
- ✅ Build: Passed
- ✅ Tests: 122 passed (28 new users tests)

Closes #77