### PR TITLE
Issue #94: API route tests rollout (Phase A complete)

### DIFF
--- a/server/controllers/time_entries.controller.ts
+++ b/server/controllers/time_entries.controller.ts
@@ -9,7 +9,7 @@ export class TimeEntriesController {
   }
 
   getByTaskId = async (req: Request, res: Response) => {
-    const { taskId } = req.params;
+    const taskId = req.params.taskId ?? req.params.id;
     const result = await this.service.getByTaskId(taskId as string);
     res.status(result.httpStatus).json(result);
   };
@@ -21,13 +21,13 @@ export class TimeEntriesController {
   };
 
   create = async (req: Request, res: Response) => {
-    const { taskId } = req.params;
+    const taskId = req.params.taskId ?? req.params.id;
     const result = await this.service.create(taskId as string, req.body);
     res.status(result.httpStatus).json(result);
   };
 
   startTimer = async (req: Request, res: Response) => {
-    const { taskId } = req.params;
+    const taskId = req.params.taskId ?? req.params.id;
     const { creatorId } = req.body;
     const result = await this.service.startTimer(taskId as string, creatorId);
     res.status(result.httpStatus).json(result);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -21,6 +21,7 @@
         "@types/express": "^5.0.6",
         "@types/node": "^25.2.3",
         "@types/pg": "^8.16.0",
+        "@types/supertest": "^7.2.0",
         "dotenv": "^17.3.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
@@ -29,6 +30,7 @@
         "prisma": "^7.4.0",
         "prisma-markdown": "^4.0.0",
         "prisma-zod-generator": "^2.1.4",
+        "supertest": "^7.2.2",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.44.1",
@@ -77,8 +79,7 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -593,6 +594,7 @@
       "integrity": "sha512-uVSdg/V4dfQmTjJzR0szNczjOH/J+FyUMMjYtr07xFRXR7EDf9i1qdxrD0VusZH9knj1/ecxzCQQxyic5NzAiA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^3.0.1",
         "debug": "^4.3.1",
@@ -608,6 +610,7 @@
       "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.1.0"
       },
@@ -621,6 +624,7 @@
       "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -655,6 +659,7 @@
       "integrity": "sha512-P9cq2dpr+LU8j3qbLygLcSZrl2/ds/pUpfnHNNuk5HW7mnngHs+6WSq5C9mO3rqRX8A1poxqLTC9cu0KOyJlBg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
@@ -665,6 +670,7 @@
       "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@eslint/core": "^1.1.0",
         "levn": "^0.4.1"
@@ -692,6 +698,7 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -702,6 +709,7 @@
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
@@ -716,6 +724,7 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -730,6 +739,7 @@
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -744,6 +754,7 @@
       "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -767,6 +778,29 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgr/core": {
@@ -807,7 +841,6 @@
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.4.0.tgz",
       "integrity": "sha512-Sc+ncr7+ph1hMf1LQfn6UyEXDEamCd5pXMsx8Q3SBH0NGX+zjqs3eaABt9hXwbcK9l7f8UyK8ldxOWA2LyPynQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/client-runtime-utils": "7.4.0"
       },
@@ -1446,6 +1479,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -1461,7 +1501,8 @@
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
       "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1506,6 +1547,14 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1577,6 +1626,30 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
@@ -1622,7 +1695,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2001,6 +2073,7 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -2011,6 +2084,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2078,6 +2152,13 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2087,6 +2168,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
@@ -2104,6 +2192,7 @@
       "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jackspeak": "^4.2.3"
       },
@@ -2141,6 +2230,7 @@
       "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -2306,6 +2396,29 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
@@ -2363,6 +2476,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -2400,7 +2520,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -2444,7 +2565,8 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
@@ -2462,6 +2584,16 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/denque": {
       "version": "2.1.0",
@@ -2488,6 +2620,17 @@
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -2589,6 +2732,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -2643,6 +2802,7 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2713,7 +2873,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2761,6 +2920,7 @@
       "integrity": "sha512-CkWE42hOJsNj9FJRaoMX9waUFYhqY4jmyLFdAdzZr6VaCg3ynLYx4WnOdkaIifGfH4gsUcBTn4OZbHXkpLD0FQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
         "@types/estree": "^1.0.8",
@@ -2793,6 +2953,7 @@
       "integrity": "sha512-WFWYhO1fV4iYkqOOvq8FbqIhr2pYfoDY0kCotMkDeNtGpiGGkZ1iov2u8ydjtgM8yF8rzK7oaTbw2NAzbAbehw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -2811,6 +2972,7 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -2824,6 +2986,7 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2837,6 +3000,7 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2857,6 +3021,7 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2972,12 +3137,21 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3046,6 +3220,7 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -3080,6 +3255,7 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -3097,6 +3273,7 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -3110,7 +3287,8 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -3129,6 +3307,46 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -3140,6 +3358,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3290,6 +3526,7 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -3355,6 +3592,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3373,7 +3626,6 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3427,6 +3679,7 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -3437,6 +3690,7 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -3462,6 +3716,7 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3472,6 +3727,7 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3505,6 +3761,7 @@
       "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^9.0.0"
       },
@@ -3543,21 +3800,24 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
@@ -3578,6 +3838,7 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -3598,6 +3859,7 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -3622,6 +3884,7 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -3709,6 +3972,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -3740,6 +4026,7 @@
       "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
@@ -3952,6 +4239,7 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -3970,6 +4258,7 @@
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -3986,6 +4275,7 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -4011,6 +4301,7 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4064,7 +4355,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -4162,7 +4452,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4270,6 +4559,7 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -4280,7 +4570,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4311,7 +4600,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "7.4.0",
         "@prisma/dev": "0.20.0",
@@ -4470,6 +4758,7 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4699,7 +4988,8 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -4945,6 +5235,42 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -5080,6 +5406,7 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -5107,7 +5434,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5172,6 +5498,7 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -5206,7 +5533,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5850,6 +6176,7 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5875,6 +6202,7 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/server/package.json
+++ b/server/package.json
@@ -65,6 +65,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^25.2.3",
     "@types/pg": "^8.16.0",
+    "@types/supertest": "^7.2.0",
     "dotenv": "^17.3.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
@@ -73,9 +74,10 @@
     "prisma": "^7.4.0",
     "prisma-markdown": "^4.0.0",
     "prisma-zod-generator": "^2.1.4",
+    "supertest": "^7.2.2",
     "tsx": "^4.21.0",
-    "vitest": "^2.1.9",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.44.1",
-    "typescript": "^5.9.3"
+    "vitest": "^2.1.9"
   }
 }

--- a/server/routes/__tests__/comments.routes.test.ts
+++ b/server/routes/__tests__/comments.routes.test.ts
@@ -1,0 +1,218 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockPrisma,
+  mockIsPrismaConflictError,
+  mockIsPrismaForeignKeyError,
+  mockIsPrismaNotFoundError,
+} = vi.hoisted(() => {
+  return {
+    mockPrisma: {
+      comment: {
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+      },
+      task: {
+        findUnique: vi.fn(),
+      },
+      project: {
+        findUnique: vi.fn(),
+      },
+      user: {
+        findUnique: vi.fn(),
+      },
+      $transaction: vi.fn(),
+    },
+    mockIsPrismaConflictError: vi.fn(() => false),
+    mockIsPrismaForeignKeyError: vi.fn(() => false),
+    mockIsPrismaNotFoundError: vi.fn(() => false),
+  };
+});
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+  isPrismaConflictError: mockIsPrismaConflictError,
+  isPrismaForeignKeyError: mockIsPrismaForeignKeyError,
+  isPrismaNotFoundError: mockIsPrismaNotFoundError,
+}));
+
+import commentsRouter from "../comments.routes";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", commentsRouter);
+  return app;
+};
+
+describe("Comments API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /api/tasks/:taskId/comments returns 404 when task is missing", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get("/api/tasks/missing/comments");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Task with ID missing not found");
+  });
+
+  it("GET /api/tasks/:taskId/comments returns list of comments", async () => {
+    const comments = [{ id: "c1", content: "hello" }];
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.comment.findMany.mockResolvedValueOnce(comments);
+
+    const response = await request(buildApp()).get("/api/tasks/t1/comments");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List comments for task t1");
+    expect(response.body.data).toEqual(comments);
+  });
+
+  it("GET /api/projects/:projectId/comments returns 404 when project is missing", async () => {
+    mockPrisma.project.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get(
+      "/api/projects/missing/comments",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Project with ID missing not found");
+  });
+
+  it("GET /api/projects/:projectId/comments returns list of comments", async () => {
+    const comments = [{ id: "c1", content: "hello" }];
+    mockPrisma.project.findUnique.mockResolvedValueOnce({ id: "p1" });
+    mockPrisma.comment.findMany.mockResolvedValueOnce(comments);
+
+    const response = await request(buildApp()).get("/api/projects/p1/comments");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List comments for project p1");
+    expect(response.body.data).toEqual(comments);
+  });
+
+  it("POST /api/comments validates exactly one target (neither)", async () => {
+    const response = await request(buildApp())
+      .post("/api/comments")
+      .send({ content: "hello", creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "Exactly one target is required: taskId or projectId",
+    );
+  });
+
+  it("POST /api/comments validates exactly one target (both)", async () => {
+    const response = await request(buildApp()).post("/api/comments").send({
+      content: "hello",
+      creatorId: "u1",
+      taskId: "t1",
+      projectId: "p1",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "Exactly one target is required: taskId or projectId",
+    );
+  });
+
+  it("POST /api/comments creates a task comment", async () => {
+    const created = { id: "c1", content: "hello", creatorId: "u1" };
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.comment.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp()).post("/api/comments").send({
+      content: "hello",
+      creatorId: "u1",
+      taskId: "t1",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Create a comment");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("GET /api/comments/:id returns 404 when comment is missing", async () => {
+    mockPrisma.comment.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get("/api/comments/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Comment with ID missing not found");
+  });
+
+  it("PUT /api/comments/:id validates creatorId is required", async () => {
+    const response = await request(buildApp())
+      .put("/api/comments/c1")
+      .send({ content: "updated" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("creatorId is required");
+  });
+
+  it("PUT /api/comments/:id returns 404 when comment is missing", async () => {
+    mockPrisma.comment.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp())
+      .put("/api/comments/missing")
+      .send({ creatorId: "u1", content: "updated" });
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Comment with ID missing not found");
+  });
+
+  it("DELETE /api/comments/:id returns 404 when comment is missing", async () => {
+    mockPrisma.comment.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).delete("/api/comments/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Comment with ID missing not found");
+  });
+
+  it("DELETE /api/comments/:id deletes comment", async () => {
+    mockPrisma.comment.findUnique.mockResolvedValueOnce({ id: "c1" });
+    mockPrisma.$transaction.mockImplementationOnce(async (callback: any) => {
+      const tx = {
+        commentTask: { deleteMany: vi.fn().mockResolvedValue({}) },
+        commentProject: { deleteMany: vi.fn().mockResolvedValue({}) },
+        comment: { delete: vi.fn().mockResolvedValue({ id: "c1" }) },
+      };
+      return callback(tx);
+    });
+
+    const response = await request(buildApp()).delete("/api/comments/c1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Delete comment with ID: c1");
+  });
+});

--- a/server/routes/__tests__/labels.routes.test.ts
+++ b/server/routes/__tests__/labels.routes.test.ts
@@ -1,0 +1,197 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, mockIsPrismaConflictError, mockIsPrismaForeignKeyError } =
+  vi.hoisted(() => {
+    return {
+      mockPrisma: {
+        label: {
+          findMany: vi.fn(),
+          create: vi.fn(),
+          findUnique: vi.fn(),
+          update: vi.fn(),
+          delete: vi.fn(),
+        },
+        user: {
+          findUnique: vi.fn(),
+        },
+      },
+      mockIsPrismaConflictError: vi.fn(() => false),
+      mockIsPrismaForeignKeyError: vi.fn(() => false),
+    };
+  });
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+  isPrismaConflictError: mockIsPrismaConflictError,
+  isPrismaForeignKeyError: mockIsPrismaForeignKeyError,
+}));
+
+import labelsRouter from "../labels.routes";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/labels", labelsRouter);
+  return app;
+};
+
+describe("Labels API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /api/labels returns 404 when no labels exist", async () => {
+    mockPrisma.label.findMany.mockResolvedValueOnce([]);
+
+    const response = await request(buildApp()).get("/api/labels");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("No labels found");
+  });
+
+  it("GET /api/labels returns list of labels", async () => {
+    const labels = [{ id: "l1", name: "Backend", color: "#ff0000" }];
+    mockPrisma.label.findMany.mockResolvedValueOnce(labels);
+
+    const response = await request(buildApp()).get("/api/labels");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List all labels");
+    expect(response.body.data).toEqual(labels);
+  });
+
+  it("POST /api/labels validates missing name", async () => {
+    const response = await request(buildApp())
+      .post("/api/labels")
+      .send({ color: "#00ff00", creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("name is required");
+  });
+
+  it("POST /api/labels validates invalid color", async () => {
+    const response = await request(buildApp())
+      .post("/api/labels")
+      .send({ name: "Backend", color: "green", creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("color must be a valid hex code");
+  });
+
+  it("POST /api/labels creates a label", async () => {
+    const created = {
+      id: "l1",
+      name: "Backend",
+      color: "#ff0000",
+      creatorId: "u1",
+    };
+
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.label.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp()).post("/api/labels").send({
+      name: "Backend",
+      color: "#ff0000",
+      creatorId: "u1",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Create a label");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("GET /api/labels/:id returns 404 when label is missing", async () => {
+    mockPrisma.label.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get("/api/labels/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Label with ID missing not found");
+  });
+
+  it("GET /api/labels/:id returns a label", async () => {
+    const label = { id: "l1", name: "Backend", color: "#ff0000" };
+    mockPrisma.label.findUnique.mockResolvedValueOnce(label);
+
+    const response = await request(buildApp()).get("/api/labels/l1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Get label by ID: l1");
+    expect(response.body.data).toEqual(label);
+  });
+
+  it("PUT /api/labels/:id validates empty update payload", async () => {
+    const response = await request(buildApp()).put("/api/labels/l1").send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "At least one field is required to update a label",
+    );
+  });
+
+  it("PUT /api/labels/:id validates invalid color", async () => {
+    const response = await request(buildApp())
+      .put("/api/labels/l1")
+      .send({ color: "blue" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("color must be a valid hex code");
+  });
+
+  it("PUT /api/labels/:id updates an existing label", async () => {
+    const updated = { id: "l1", name: "Frontend", color: "#0000ff" };
+    mockPrisma.label.findUnique.mockResolvedValueOnce({ id: "l1" });
+    mockPrisma.label.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .put("/api/labels/l1")
+      .send({ name: "Frontend", color: "#0000ff" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Update label with ID: l1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("DELETE /api/labels/:id returns 404 when label is missing", async () => {
+    mockPrisma.label.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).delete("/api/labels/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Label with ID missing not found");
+  });
+
+  it("DELETE /api/labels/:id deletes a label", async () => {
+    mockPrisma.label.findUnique.mockResolvedValueOnce({ id: "l1" });
+    mockPrisma.label.delete.mockResolvedValueOnce({ id: "l1" });
+
+    const response = await request(buildApp()).delete("/api/labels/l1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Delete label with ID: l1");
+  });
+});

--- a/server/routes/__tests__/priorities.routes.test.ts
+++ b/server/routes/__tests__/priorities.routes.test.ts
@@ -1,0 +1,201 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, mockIsPrismaConflictError, mockIsPrismaForeignKeyError } =
+  vi.hoisted(() => {
+    return {
+      mockPrisma: {
+        priority: {
+          findMany: vi.fn(),
+          create: vi.fn(),
+          findUnique: vi.fn(),
+          update: vi.fn(),
+          delete: vi.fn(),
+        },
+        user: {
+          findUnique: vi.fn(),
+        },
+      },
+      mockIsPrismaConflictError: vi.fn(() => false),
+      mockIsPrismaForeignKeyError: vi.fn(() => false),
+    };
+  });
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+  isPrismaConflictError: mockIsPrismaConflictError,
+  isPrismaForeignKeyError: mockIsPrismaForeignKeyError,
+}));
+
+import prioritiesRouter from "../priorities.routes";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/priorities", prioritiesRouter);
+  return app;
+};
+
+describe("Priorities API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /api/priorities returns 404 when no priorities exist", async () => {
+    mockPrisma.priority.findMany.mockResolvedValueOnce([]);
+
+    const response = await request(buildApp()).get("/api/priorities");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("No priorities found");
+  });
+
+  it("GET /api/priorities returns list of priorities", async () => {
+    const priorities = [{ id: "p1", name: "High", color: "#ff0000" }];
+    mockPrisma.priority.findMany.mockResolvedValueOnce(priorities);
+
+    const response = await request(buildApp()).get("/api/priorities");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List all priorities");
+    expect(response.body.data).toEqual(priorities);
+  });
+
+  it("POST /api/priorities validates missing name", async () => {
+    const response = await request(buildApp())
+      .post("/api/priorities")
+      .send({ color: "#00ff00", creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("name is required");
+  });
+
+  it("POST /api/priorities validates invalid color", async () => {
+    const response = await request(buildApp())
+      .post("/api/priorities")
+      .send({ name: "High", color: "red", creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("color must be a valid hex code");
+  });
+
+  it("POST /api/priorities creates a priority", async () => {
+    const created = {
+      id: "p1",
+      name: "High",
+      color: "#ff0000",
+      creatorId: "u1",
+    };
+
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.priority.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp()).post("/api/priorities").send({
+      name: "High",
+      color: "#ff0000",
+      creatorId: "u1",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Create a priority");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("GET /api/priorities/:id returns 404 when priority is missing", async () => {
+    mockPrisma.priority.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get("/api/priorities/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Priority with ID missing not found");
+  });
+
+  it("GET /api/priorities/:id returns a priority", async () => {
+    const priority = { id: "p1", name: "High", color: "#ff0000" };
+    mockPrisma.priority.findUnique.mockResolvedValueOnce(priority);
+
+    const response = await request(buildApp()).get("/api/priorities/p1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Get priority by ID: p1");
+    expect(response.body.data).toEqual(priority);
+  });
+
+  it("PUT /api/priorities/:id validates empty update payload", async () => {
+    const response = await request(buildApp())
+      .put("/api/priorities/p1")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "At least one field is required to update a priority",
+    );
+  });
+
+  it("PUT /api/priorities/:id validates invalid color", async () => {
+    const response = await request(buildApp())
+      .put("/api/priorities/p1")
+      .send({ color: "blue" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("color must be a valid hex code");
+  });
+
+  it("PUT /api/priorities/:id updates an existing priority", async () => {
+    const updated = { id: "p1", name: "Low", color: "#0000ff" };
+    mockPrisma.priority.findUnique.mockResolvedValueOnce({ id: "p1" });
+    mockPrisma.priority.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .put("/api/priorities/p1")
+      .send({ name: "Low", color: "#0000ff" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Update priority with ID: p1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("DELETE /api/priorities/:id returns 404 when priority is missing", async () => {
+    mockPrisma.priority.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).delete(
+      "/api/priorities/missing",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Priority with ID missing not found");
+  });
+
+  it("DELETE /api/priorities/:id deletes a priority", async () => {
+    mockPrisma.priority.findUnique.mockResolvedValueOnce({ id: "p1" });
+    mockPrisma.priority.delete.mockResolvedValueOnce({ id: "p1" });
+
+    const response = await request(buildApp()).delete("/api/priorities/p1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Delete priority with ID: p1");
+  });
+});

--- a/server/routes/__tests__/projects.routes.test.ts
+++ b/server/routes/__tests__/projects.routes.test.ts
@@ -1,0 +1,216 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockPrisma,
+  mockIsPrismaConflictError,
+  mockIsPrismaForeignKeyError,
+  mockIsPrismaNotFoundError,
+} = vi.hoisted(() => {
+  return {
+    mockPrisma: {
+      project: {
+        findMany: vi.fn(),
+        create: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      },
+      user: {
+        findUnique: vi.fn(),
+      },
+    },
+    mockIsPrismaConflictError: vi.fn(() => false),
+    mockIsPrismaForeignKeyError: vi.fn(() => false),
+    mockIsPrismaNotFoundError: vi.fn(() => false),
+  };
+});
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+  isPrismaConflictError: mockIsPrismaConflictError,
+  isPrismaForeignKeyError: mockIsPrismaForeignKeyError,
+  isPrismaNotFoundError: mockIsPrismaNotFoundError,
+  normalizeWithLabelsAndComments: <T>(entity: T) => entity,
+  normalizeManyWithLabelsAndComments: <T>(entities: T[]) => entities,
+}));
+
+import projectsRouter from "../projects.routes";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/projects", projectsRouter);
+  return app;
+};
+
+describe("Projects API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /api/projects returns 404 when no projects exist", async () => {
+    mockPrisma.project.findMany.mockResolvedValueOnce([]);
+
+    const response = await request(buildApp()).get("/api/projects");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("No projects found");
+  });
+
+  it("GET /api/projects returns projects list", async () => {
+    const projects = [{ id: "p1", name: "Alpha", isArchived: false }];
+    mockPrisma.project.findMany.mockResolvedValueOnce(projects);
+
+    const response = await request(buildApp()).get("/api/projects");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List all projects");
+    expect(response.body.data).toEqual(projects);
+  });
+
+  it("POST /api/projects validates required name", async () => {
+    const response = await request(buildApp())
+      .post("/api/projects")
+      .send({ creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Project name is required");
+  });
+
+  it("POST /api/projects creates project", async () => {
+    const created = { id: "p1", name: "Alpha", creatorId: "u1" };
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.project.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp()).post("/api/projects").send({
+      name: "Alpha",
+      creatorId: "u1",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Create a project");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("GET /api/projects/:id returns 404 when project is missing", async () => {
+    mockPrisma.project.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get("/api/projects/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Project with ID missing not found");
+  });
+
+  it("PUT /api/projects/:id validates empty name", async () => {
+    const response = await request(buildApp())
+      .put("/api/projects/p1")
+      .send({ name: "  " });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Project name cannot be empty");
+  });
+
+  it("PUT /api/projects/:id updates project", async () => {
+    const updated = { id: "p1", name: "Alpha v2" };
+    mockPrisma.project.findUnique.mockResolvedValueOnce({ id: "p1" });
+    mockPrisma.project.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .put("/api/projects/p1")
+      .send({ name: "Alpha v2" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Update project with ID: p1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("DELETE /api/projects/:id returns 404 when project is missing", async () => {
+    mockPrisma.project.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).delete("/api/projects/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Project with ID missing not found");
+  });
+
+  it("PUT /api/projects/:id/archive archives project", async () => {
+    const archived = { id: "p1", isArchived: true };
+    mockPrisma.project.findUnique.mockResolvedValueOnce({ id: "p1" });
+    mockPrisma.project.update.mockResolvedValueOnce(archived);
+
+    const response = await request(buildApp()).put("/api/projects/p1/archive");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Archive project with ID: p1");
+    expect(response.body.data).toEqual(archived);
+  });
+
+  it("PUT /api/projects/:id/unarchive unarchives project", async () => {
+    const unarchived = { id: "p1", isArchived: false };
+    mockPrisma.project.findUnique.mockResolvedValueOnce({ id: "p1" });
+    mockPrisma.project.update.mockResolvedValueOnce(unarchived);
+
+    const response = await request(buildApp()).put("/api/projects/p1/unarchive");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Unarchive project with ID: p1");
+    expect(response.body.data).toEqual(unarchived);
+  });
+
+  it("POST /api/projects/:id/assignee validates missing userId", async () => {
+    const response = await request(buildApp())
+      .post("/api/projects/p1/assignee")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("User ID is required");
+  });
+
+  it("POST /api/projects/:id/assignee assigns user", async () => {
+    const updated = { id: "p1" };
+    mockPrisma.project.findUnique.mockResolvedValueOnce({ id: "p1" });
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.project.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .post("/api/projects/p1/assignee")
+      .send({ userId: "u1" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Assign user u1 to project p1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("DELETE /api/projects/:id/assignee validates missing userId", async () => {
+    const response = await request(buildApp())
+      .delete("/api/projects/p1/assignee")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("User ID is required");
+  });
+});

--- a/server/routes/__tests__/roles.routes.test.ts
+++ b/server/routes/__tests__/roles.routes.test.ts
@@ -1,0 +1,197 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, mockIsPrismaConflictError, mockIsPrismaForeignKeyError } =
+  vi.hoisted(() => {
+    return {
+      mockPrisma: {
+        role: {
+          findMany: vi.fn(),
+          create: vi.fn(),
+          findUnique: vi.fn(),
+          update: vi.fn(),
+          delete: vi.fn(),
+        },
+        user: {
+          findUnique: vi.fn(),
+        },
+      },
+      mockIsPrismaConflictError: vi.fn(() => false),
+      mockIsPrismaForeignKeyError: vi.fn(() => false),
+    };
+  });
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+  isPrismaConflictError: mockIsPrismaConflictError,
+  isPrismaForeignKeyError: mockIsPrismaForeignKeyError,
+}));
+
+import rolesRouter from "../roles.routes";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/roles", rolesRouter);
+  return app;
+};
+
+describe("Roles API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /api/roles returns 404 when no roles exist", async () => {
+    mockPrisma.role.findMany.mockResolvedValueOnce([]);
+
+    const response = await request(buildApp()).get("/api/roles");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("No roles found");
+  });
+
+  it("GET /api/roles returns list of roles", async () => {
+    const roles = [{ id: "r1", name: "Admin", color: "#ff0000" }];
+    mockPrisma.role.findMany.mockResolvedValueOnce(roles);
+
+    const response = await request(buildApp()).get("/api/roles");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List all roles");
+    expect(response.body.data).toEqual(roles);
+  });
+
+  it("POST /api/roles validates missing name", async () => {
+    const response = await request(buildApp())
+      .post("/api/roles")
+      .send({ color: "#00ff00", creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("name is required");
+  });
+
+  it("POST /api/roles validates invalid color", async () => {
+    const response = await request(buildApp())
+      .post("/api/roles")
+      .send({ name: "Admin", color: "red", creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("color must be a valid hex code");
+  });
+
+  it("POST /api/roles creates a role", async () => {
+    const created = {
+      id: "r1",
+      name: "Admin",
+      color: "#ff0000",
+      creatorId: "u1",
+    };
+
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.role.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp()).post("/api/roles").send({
+      name: "Admin",
+      color: "#ff0000",
+      creatorId: "u1",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Create a role");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("GET /api/roles/:id returns 404 when role is missing", async () => {
+    mockPrisma.role.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get("/api/roles/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Role with ID missing not found");
+  });
+
+  it("GET /api/roles/:id returns a role", async () => {
+    const role = { id: "r1", name: "Admin", color: "#ff0000" };
+    mockPrisma.role.findUnique.mockResolvedValueOnce(role);
+
+    const response = await request(buildApp()).get("/api/roles/r1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Get role by ID: r1");
+    expect(response.body.data).toEqual(role);
+  });
+
+  it("PUT /api/roles/:id validates empty update payload", async () => {
+    const response = await request(buildApp()).put("/api/roles/r1").send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "At least one field is required to update a role",
+    );
+  });
+
+  it("PUT /api/roles/:id validates invalid color", async () => {
+    const response = await request(buildApp())
+      .put("/api/roles/r1")
+      .send({ color: "blue" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("color must be a valid hex code");
+  });
+
+  it("PUT /api/roles/:id updates an existing role", async () => {
+    const updated = { id: "r1", name: "Member", color: "#0000ff" };
+    mockPrisma.role.findUnique.mockResolvedValueOnce({ id: "r1" });
+    mockPrisma.role.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .put("/api/roles/r1")
+      .send({ name: "Member", color: "#0000ff" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Update role with ID: r1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("DELETE /api/roles/:id returns 404 when role is missing", async () => {
+    mockPrisma.role.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).delete("/api/roles/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Role with ID missing not found");
+  });
+
+  it("DELETE /api/roles/:id deletes a role", async () => {
+    mockPrisma.role.findUnique.mockResolvedValueOnce({ id: "r1" });
+    mockPrisma.role.delete.mockResolvedValueOnce({ id: "r1" });
+
+    const response = await request(buildApp()).delete("/api/roles/r1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Delete role with ID: r1");
+  });
+});

--- a/server/routes/__tests__/statuses.routes.test.ts
+++ b/server/routes/__tests__/statuses.routes.test.ts
@@ -1,0 +1,199 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma, mockIsPrismaConflictError, mockIsPrismaForeignKeyError } =
+  vi.hoisted(() => {
+    return {
+      mockPrisma: {
+        status: {
+          findMany: vi.fn(),
+          create: vi.fn(),
+          findUnique: vi.fn(),
+          update: vi.fn(),
+          delete: vi.fn(),
+        },
+        user: {
+          findUnique: vi.fn(),
+        },
+      },
+      mockIsPrismaConflictError: vi.fn(() => false),
+      mockIsPrismaForeignKeyError: vi.fn(() => false),
+    };
+  });
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+  isPrismaConflictError: mockIsPrismaConflictError,
+  isPrismaForeignKeyError: mockIsPrismaForeignKeyError,
+}));
+
+import statusesRouter from "../statuses.routes";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/statuses", statusesRouter);
+  return app;
+};
+
+describe("Statuses API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /api/statuses returns 404 when no statuses exist", async () => {
+    mockPrisma.status.findMany.mockResolvedValueOnce([]);
+
+    const response = await request(buildApp()).get("/api/statuses");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("No statuses found");
+  });
+
+  it("GET /api/statuses returns list of statuses", async () => {
+    const statuses = [{ id: "s1", name: "Todo", color: "#ff0000" }];
+    mockPrisma.status.findMany.mockResolvedValueOnce(statuses);
+
+    const response = await request(buildApp()).get("/api/statuses");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List all statuses");
+    expect(response.body.data).toEqual(statuses);
+  });
+
+  it("POST /api/statuses validates missing name", async () => {
+    const response = await request(buildApp())
+      .post("/api/statuses")
+      .send({ color: "#00ff00", creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("name is required");
+  });
+
+  it("POST /api/statuses validates invalid color", async () => {
+    const response = await request(buildApp())
+      .post("/api/statuses")
+      .send({ name: "Todo", color: "red", creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("color must be a valid hex code");
+  });
+
+  it("POST /api/statuses creates a status", async () => {
+    const created = {
+      id: "s1",
+      name: "Todo",
+      color: "#ff0000",
+      creatorId: "u1",
+    };
+
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.status.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp()).post("/api/statuses").send({
+      name: "Todo",
+      color: "#ff0000",
+      creatorId: "u1",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Create a status");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("GET /api/statuses/:id returns 404 when status is missing", async () => {
+    mockPrisma.status.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get("/api/statuses/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Status with ID missing not found");
+  });
+
+  it("GET /api/statuses/:id returns a status", async () => {
+    const status = { id: "s1", name: "Todo", color: "#ff0000" };
+    mockPrisma.status.findUnique.mockResolvedValueOnce(status);
+
+    const response = await request(buildApp()).get("/api/statuses/s1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Get status by ID: s1");
+    expect(response.body.data).toEqual(status);
+  });
+
+  it("PUT /api/statuses/:id validates empty update payload", async () => {
+    const response = await request(buildApp())
+      .put("/api/statuses/s1")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "At least one field is required to update a status",
+    );
+  });
+
+  it("PUT /api/statuses/:id validates invalid color", async () => {
+    const response = await request(buildApp())
+      .put("/api/statuses/s1")
+      .send({ color: "blue" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("color must be a valid hex code");
+  });
+
+  it("PUT /api/statuses/:id updates an existing status", async () => {
+    const updated = { id: "s1", name: "Done", color: "#0000ff" };
+    mockPrisma.status.findUnique.mockResolvedValueOnce({ id: "s1" });
+    mockPrisma.status.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .put("/api/statuses/s1")
+      .send({ name: "Done", color: "#0000ff" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Update status with ID: s1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("DELETE /api/statuses/:id returns 404 when status is missing", async () => {
+    mockPrisma.status.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).delete("/api/statuses/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Status with ID missing not found");
+  });
+
+  it("DELETE /api/statuses/:id deletes a status", async () => {
+    mockPrisma.status.findUnique.mockResolvedValueOnce({ id: "s1" });
+    mockPrisma.status.delete.mockResolvedValueOnce({ id: "s1" });
+
+    const response = await request(buildApp()).delete("/api/statuses/s1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Delete status with ID: s1");
+  });
+});

--- a/server/routes/__tests__/tasks.routes.test.ts
+++ b/server/routes/__tests__/tasks.routes.test.ts
@@ -1,0 +1,325 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockPrisma,
+  mockIsPrismaConflictError,
+  mockIsPrismaForeignKeyError,
+  mockIsPrismaNotFoundError,
+} = vi.hoisted(() => {
+  return {
+    mockPrisma: {
+      task: {
+        findMany: vi.fn(),
+        create: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      },
+      user: {
+        findUnique: vi.fn(),
+      },
+      priority: {
+        findUnique: vi.fn(),
+      },
+      status: {
+        findUnique: vi.fn(),
+      },
+      project: {
+        findUnique: vi.fn(),
+      },
+      label: {
+        findMany: vi.fn(),
+      },
+      taskLabel: {
+        findMany: vi.fn(),
+      },
+    },
+    mockIsPrismaConflictError: vi.fn(() => false),
+    mockIsPrismaForeignKeyError: vi.fn(() => false),
+    mockIsPrismaNotFoundError: vi.fn(() => false),
+  };
+});
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+  isPrismaConflictError: mockIsPrismaConflictError,
+  isPrismaForeignKeyError: mockIsPrismaForeignKeyError,
+  isPrismaNotFoundError: mockIsPrismaNotFoundError,
+  normalizeTaskWithDetails: <T>(entity: T) => entity,
+  normalizeManyTasksWithDetails: <T>(entities: T[]) => entities,
+}));
+
+import tasksRouter from "../tasks.routes";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/tasks", tasksRouter);
+  return app;
+};
+
+describe("Tasks API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /api/tasks returns 404 when no tasks exist", async () => {
+    mockPrisma.task.findMany.mockResolvedValueOnce([]);
+
+    const response = await request(buildApp()).get("/api/tasks");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("No tasks found");
+  });
+
+  it("GET /api/tasks returns list of tasks", async () => {
+    const tasks = [{ id: "t1", title: "Task A", isArchived: false }];
+    mockPrisma.task.findMany.mockResolvedValueOnce(tasks);
+
+    const response = await request(buildApp()).get("/api/tasks");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List all tasks");
+    expect(response.body.data).toEqual(tasks);
+  });
+
+  it("POST /api/tasks validates missing title", async () => {
+    const response = await request(buildApp())
+      .post("/api/tasks")
+      .send({ creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("title is required");
+  });
+
+  it("POST /api/tasks creates a task", async () => {
+    const created = { id: "t1", title: "Task A", creatorId: "u1" };
+
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.task.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp()).post("/api/tasks").send({
+      title: "Task A",
+      creatorId: "u1",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Create a task");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("GET /api/tasks/:id returns 404 when task is missing", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get("/api/tasks/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Task with ID missing not found");
+  });
+
+  it("PUT /api/tasks/:id validates empty update payload", async () => {
+    const response = await request(buildApp()).put("/api/tasks/t1").send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "At least one field is required to update a task",
+    );
+  });
+
+  it("DELETE /api/tasks/:id returns 404 when task is missing", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).delete("/api/tasks/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Task with ID missing not found");
+  });
+
+  it("POST /api/tasks/:id/labels validates non-empty labelIds", async () => {
+    const response = await request(buildApp())
+      .post("/api/tasks/t1/labels")
+      .send({ labelIds: [] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("labelIds must be a non-empty array");
+  });
+
+  it("POST /api/tasks/:id/labels adds labels", async () => {
+    const updated = { id: "t1", labelLinks: [] };
+
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.label.findMany.mockResolvedValueOnce([{ id: "l1" }]);
+    mockPrisma.taskLabel.findMany.mockResolvedValueOnce([]);
+    mockPrisma.task.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .post("/api/tasks/t1/labels")
+      .send({ labelIds: ["l1"] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Add labels to task t1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("DELETE /api/tasks/:id/labels returns 404 when task is missing", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp())
+      .delete("/api/tasks/missing/labels")
+      .send({ labelIds: ["l1"] });
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Task with ID missing not found");
+  });
+
+  it("PUT /api/tasks/:id/priority validates missing priorityId", async () => {
+    const response = await request(buildApp())
+      .put("/api/tasks/t1/priority")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("priorityId is required");
+  });
+
+  it("PUT /api/tasks/:id/priority sets task priority", async () => {
+    const updated = { id: "t1", priorityId: "p1" };
+
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.priority.findUnique.mockResolvedValueOnce({ id: "p1" });
+    mockPrisma.task.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .put("/api/tasks/t1/priority")
+      .send({ priorityId: "p1" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Set priority for task t1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("PUT /api/tasks/:id/status validates missing statusId", async () => {
+    const response = await request(buildApp())
+      .put("/api/tasks/t1/status")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("statusId is required");
+  });
+
+  it("PUT /api/tasks/:id/project validates missing projectId", async () => {
+    const response = await request(buildApp())
+      .put("/api/tasks/t1/project")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("projectId is required");
+  });
+
+  it("DELETE /api/tasks/:id/project returns 404 when task is missing", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).delete("/api/tasks/missing/project");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Task with ID missing not found");
+  });
+
+  it("PUT /api/tasks/:id/archive archives a task", async () => {
+    const updated = { id: "t1", isArchived: true };
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.task.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp()).put("/api/tasks/t1/archive");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Archive task with ID: t1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("PUT /api/tasks/:id/unarchive unarchives a task", async () => {
+    const updated = { id: "t1", isArchived: false };
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.task.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp()).put("/api/tasks/t1/unarchive");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Unarchive task with ID: t1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("POST /api/tasks/:id/assignee validates missing userId", async () => {
+    const response = await request(buildApp())
+      .post("/api/tasks/t1/assignee")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("userId is required");
+  });
+
+  it("POST /api/tasks/:id/assignee assigns a user", async () => {
+    const updated = { id: "t1" };
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.task.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .post("/api/tasks/t1/assignee")
+      .send({ userId: "u1" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Assign user u1 to task t1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("DELETE /api/tasks/:id/assignee validates missing userId", async () => {
+    const response = await request(buildApp())
+      .delete("/api/tasks/t1/assignee")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("userId is required");
+  });
+
+  it("POST /api/tasks/:id/watchers validates missing userId", async () => {
+    const response = await request(buildApp())
+      .post("/api/tasks/t1/watchers")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("userId is required");
+  });
+
+  it("DELETE /api/tasks/:id/watchers validates missing userId", async () => {
+    const response = await request(buildApp())
+      .delete("/api/tasks/t1/watchers")
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("userId is required");
+  });
+});

--- a/server/routes/__tests__/timeEntries.routes.test.ts
+++ b/server/routes/__tests__/timeEntries.routes.test.ts
@@ -1,0 +1,231 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => {
+  return {
+    mockPrisma: {
+      timeEntry: {
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        findFirst: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      },
+      task: {
+        findUnique: vi.fn(),
+      },
+      user: {
+        findUnique: vi.fn(),
+      },
+    },
+  };
+});
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+}));
+
+import tasksRouter from "../tasks.routes";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/tasks", tasksRouter);
+  return app;
+};
+
+describe("TimeEntries API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /api/tasks/:id/time-entries lists entries", async () => {
+    const entries = [{ id: "te1", taskId: "t1" }];
+    mockPrisma.timeEntry.findMany.mockResolvedValueOnce(entries);
+
+    const response = await request(buildApp()).get(
+      "/api/tasks/t1/time-entries",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List time entries for task t1");
+    expect(response.body.data).toEqual(entries);
+  });
+
+  it("POST /api/tasks/:id/time-entries returns 404 when task is missing", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp())
+      .post("/api/tasks/missing/time-entries")
+      .send({
+        creatorId: "u1",
+        startDate: new Date().toISOString(),
+        duration: 1,
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Task with ID missing not found");
+  });
+
+  it("POST /api/tasks/:id/time-entries creates entry", async () => {
+    const created = { id: "te1", taskId: "t1" };
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.timeEntry.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp())
+      .post("/api/tasks/t1/time-entries")
+      .send({
+        creatorId: "u1",
+        startDate: new Date().toISOString(),
+        duration: 1,
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Create time entry");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("POST /api/tasks/:id/time-entries/start validates missing task", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp())
+      .post("/api/tasks/missing/time-entries/start")
+      .send({ creatorId: "u1" });
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Task with ID missing not found");
+  });
+
+  it("POST /api/tasks/:id/time-entries/start validates missing user", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.user.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp())
+      .post("/api/tasks/t1/time-entries/start")
+      .send({ creatorId: "missing-user" });
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("User with ID missing-user not found");
+  });
+
+  it("POST /api/tasks/:id/time-entries/start rejects when timer already running", async () => {
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.timeEntry.findFirst.mockResolvedValueOnce({ id: "running" });
+
+    const response = await request(buildApp())
+      .post("/api/tasks/t1/time-entries/start")
+      .send({ creatorId: "u1" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe(
+      "A timer is already running for this task",
+    );
+  });
+
+  it("POST /api/tasks/:id/time-entries/start starts timer", async () => {
+    const created = { id: "te1", taskId: "t1", creatorId: "u1", duration: 0 };
+    mockPrisma.task.findUnique.mockResolvedValueOnce({ id: "t1" });
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.timeEntry.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.timeEntry.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp())
+      .post("/api/tasks/t1/time-entries/start")
+      .send({ creatorId: "u1" });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Timer started");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("GET /api/tasks/:id/time-entries/:id returns 404 when entry is missing", async () => {
+    mockPrisma.timeEntry.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get(
+      "/api/tasks/t1/time-entries/missing",
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Time entry with ID missing not found");
+  });
+
+  it("PUT /api/tasks/:id/time-entries/:id returns 404 when entry is missing", async () => {
+    mockPrisma.timeEntry.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp())
+      .put("/api/tasks/t1/time-entries/missing")
+      .send({ duration: 2 });
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("Time entry with ID missing not found");
+  });
+
+  it("POST /api/tasks/:id/time-entries/:id/stop rejects stopped timer", async () => {
+    mockPrisma.timeEntry.findUnique.mockResolvedValueOnce({
+      id: "te1",
+      startDate: new Date(),
+      endDate: new Date(),
+    });
+
+    const response = await request(buildApp()).post(
+      "/api/tasks/t1/time-entries/te1/stop",
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Timer already stopped");
+  });
+
+  it("POST /api/tasks/:id/time-entries/:id/stop stops timer", async () => {
+    const updated = { id: "te1", endDate: new Date().toISOString() };
+    mockPrisma.timeEntry.findUnique.mockResolvedValueOnce({
+      id: "te1",
+      startDate: new Date(Date.now() - 1000 * 60 * 60),
+      endDate: null,
+    });
+    mockPrisma.timeEntry.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp()).post(
+      "/api/tasks/t1/time-entries/te1/stop",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Timer stopped");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("DELETE /api/tasks/:id/time-entries/:id handles delete", async () => {
+    mockPrisma.timeEntry.delete.mockResolvedValueOnce({ id: "te1" });
+
+    const response = await request(buildApp()).delete(
+      "/api/tasks/t1/time-entries/te1",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Delete time entry with ID: te1");
+  });
+});

--- a/server/routes/__tests__/users.routes.test.ts
+++ b/server/routes/__tests__/users.routes.test.ts
@@ -1,0 +1,203 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockPrisma,
+  mockIsPrismaConflictError,
+  mockIsPrismaForeignKeyError,
+  mockIsPrismaNotFoundError,
+} = vi.hoisted(() => {
+  return {
+    mockPrisma: {
+      user: {
+        findMany: vi.fn(),
+        create: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      },
+      role: {
+        findUnique: vi.fn(),
+      },
+    },
+    mockIsPrismaConflictError: vi.fn(() => false),
+    mockIsPrismaForeignKeyError: vi.fn(() => false),
+    mockIsPrismaNotFoundError: vi.fn(() => false),
+  };
+});
+
+vi.mock("../../utils", () => ({
+  prisma: mockPrisma,
+  standardiseResponse: ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }: {
+    message: string;
+    httpStatus: number;
+    data?: unknown;
+    error?: unknown;
+    pagination?: unknown;
+    sorting?: unknown;
+  }) => ({
+    message,
+    httpStatus,
+    data,
+    error,
+    pagination,
+    sorting,
+  }),
+  isPrismaConflictError: mockIsPrismaConflictError,
+  isPrismaForeignKeyError: mockIsPrismaForeignKeyError,
+  isPrismaNotFoundError: mockIsPrismaNotFoundError,
+}));
+
+import usersRouter from "../users.routes";
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/users", usersRouter);
+  return app;
+};
+
+describe("Users API routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /api/users returns 404 when no users exist", async () => {
+    mockPrisma.user.findMany.mockResolvedValueOnce([]);
+
+    const response = await request(buildApp()).get("/api/users");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("No users found");
+  });
+
+  it("GET /api/users returns list of users", async () => {
+    const users = [{ id: "u1", name: "Alice", email: "alice@acme.com" }];
+    mockPrisma.user.findMany.mockResolvedValueOnce(users);
+
+    const response = await request(buildApp()).get("/api/users");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("List all users");
+    expect(response.body.data).toEqual(users);
+  });
+
+  it("POST /api/users validates missing name", async () => {
+    const response = await request(buildApp())
+      .post("/api/users")
+      .send({ email: "alice@acme.com" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("User name is required");
+  });
+
+  it("POST /api/users validates missing email", async () => {
+    const response = await request(buildApp())
+      .post("/api/users")
+      .send({ name: "Alice" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("User email is required");
+  });
+
+  it("POST /api/users validates unknown role", async () => {
+    mockPrisma.role.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).post("/api/users").send({
+      name: "Alice",
+      email: "alice@acme.com",
+      roleId: "missing-role",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Role with ID missing-role not found");
+  });
+
+  it("POST /api/users creates a user", async () => {
+    const created = { id: "u1", name: "Alice", email: "alice@acme.com" };
+    mockPrisma.user.create.mockResolvedValueOnce(created);
+
+    const response = await request(buildApp()).post("/api/users").send({
+      name: "Alice",
+      email: "alice@acme.com",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body.message).toBe("Create a user");
+    expect(response.body.data).toEqual(created);
+  });
+
+  it("GET /api/users/:id returns 404 when user is missing", async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).get("/api/users/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("User with ID missing not found");
+  });
+
+  it("PUT /api/users/:id validates empty name", async () => {
+    const response = await request(buildApp())
+      .put("/api/users/u1")
+      .send({ name: "  " });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("User name cannot be empty");
+  });
+
+  it("PUT /api/users/:id updates a user", async () => {
+    const updated = { id: "u1", name: "Alice Updated", email: "alice@acme.com" };
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.user.update.mockResolvedValueOnce(updated);
+
+    const response = await request(buildApp())
+      .put("/api/users/u1")
+      .send({ name: "Alice Updated" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Update user with ID: u1");
+    expect(response.body.data).toEqual(updated);
+  });
+
+  it("PUT /api/users/:id handles duplicate email conflict", async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockIsPrismaConflictError.mockReturnValueOnce(true);
+    mockPrisma.user.update.mockRejectedValueOnce(new Error("Unique constraint"));
+
+    const response = await request(buildApp())
+      .put("/api/users/u1")
+      .send({ email: "dup@acme.com" });
+
+    expect(response.status).toBe(409);
+    expect(response.body.message).toBe("User with this email already exists");
+  });
+
+  it("DELETE /api/users/:id returns 404 when user is missing", async () => {
+    mockPrisma.user.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(buildApp()).delete("/api/users/missing");
+
+    expect(response.status).toBe(404);
+    expect(response.body.message).toBe("User with ID missing not found");
+  });
+
+  it("DELETE /api/users/:id deletes a user", async () => {
+    const deleted = { id: "u1", name: "Alice", email: "alice@acme.com" };
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ id: "u1" });
+    mockPrisma.user.delete.mockResolvedValueOnce(deleted);
+
+    const response = await request(buildApp()).delete("/api/users/u1");
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe("Delete user with ID: u1");
+    expect(response.body.data).toEqual(deleted);
+  });
+});


### PR DESCRIPTION
## Summary
- deliver entity-by-entity Phase A API route test suites for labels, priorities, roles, tasks, comments, statuses, time entries, users, and projects
- include controller param fix for nested time entries routes
- merge all child issue branches (#95-#103) into branch maquejp/issue94

## Validation
- npm test (server)
- 17 test files, 255 tests passing

Closes #94